### PR TITLE
Initial Version of Hathi Reader

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+omit =
+  tests/*
+  */site-packages/*
+
+[report]
+exclude_lines =
+  if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+dist/
+htmlcov/
+__pycache__/
+*.pyc
+.coverage
+setup.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+dist: xenial
+python:
+  - 3.6
+  - 3.7
+install:
+  - pip install --upgrade pip
+  - pip install -r requirements.txt
+before_script: cp config.yaml.sample config.yaml
+script: make test
+#
+# The travis configuration beloy will deploy this lambda to the function defined
+# in your config.yaml file. This behavior can be defined for any of the
+# development/qa/production environments.
+#
+# after_success:
+#  - ENVIRONMENT_NAME=$TRAVIS_BRANCH
+#  - if [ "$TRAVIS_BRANCH" == "master" ]; then ENVIRONMENT_NAME=production; fi
+# deploy:
+#  - provider: script
+#    skip_cleanup: true
+#    script: "make deploy ENV=$ENVIRONMENT_NAME"
+#    on:
+#      branch: development
+#
+# If you are deploying an NYPL Lambda, see the engineering documentation in
+# github for instructions on adding encrypted variables to you travis scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 install:
   - pip install --upgrade pip
   - pip install -r requirements.txt
-before_script: cp config.yaml.sample config.yaml
 script: make test
 #
 # The travis configuration beloy will deploy this lambda to the function defined

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+
+
+.DEFAULT: help
+help:
+	@echo "make help"
+	@echo "    display this help statement"
+	@echo "make deploy"
+	@echo "    deploy lambda using python-lambda to the environemnt specified as: "
+	@echo "    make deploy ENV=[environment]"
+	@echo "make run-local"
+	@echo "    invoke python-lambda's local test environement"
+	@echo "    uses the development environemnt variables and the events in event.json"
+	@echo "make build-ENV"
+	@echo "    package the lambda for upload to AWS. Puts output in dist/"
+	@echo "make test"
+	@echo "    runs unittests defined in tests/ directory"
+	@echo "make coverage-report"
+	@echo "    display report on test coverage"
+	@echo "make lint"
+	@echo "    lint package with flake8"
+
+deploy:
+	python3 -m scripts.lambdaRun $(ENV)
+
+run-local:
+	python3 -m scripts.lambdaRun run-local
+
+build:
+	python3 -m scripts.lambdaRun build-$(ENV)
+
+test:
+	coverage run -m unittest
+
+coverage-report:
+	coverage report -m
+
+lint:
+	flake8

--- a/README.md
+++ b/README.md
@@ -45,3 +45,16 @@ It is recommended that local development and testing of this function be done in
 Tests can be run via the `make test` and linting through `make lint` command and local execution (using a local CSV file) can be done with `make local-run`
 
 To deploy the function to a Lambda in you AWS environment run `make deploy ENV=[environment]` where environment designates the desired YAML file you'd like to deploy with.
+
+
+## A Note on Data
+Several transformations are applied to the HathiTrust data as it is received in order to best conform it to match the SFR data model.
+1. The `htid` that uniquely identifies each item can be, and is, used to create URLs at which the item itself (a PDF file) can be viewed and downloaded
+2. HathiTrust data contains a robust set of rights data, this is combined into a single class in the SFR data model and associated with both the `instance` and `item` that are created from the Hathi item.
+3. In the TSV format accessed here, several metadata fields are collapsed into single columns. This data exists separately in MARC files accessible via the HathiTrust API. If this data needs to be accessed separately, an additional step calling this API will need to be added to this function.
+
+## TODO
+- Improve/verify institution code translations for all fields where used
+- Improve parsing of lifespan dates and other fields from author column
+- Improve publication place/year parsing from publication info column
+- Investigate ways of matching/aligning records with existing records imported from OCLC that contain `links` to HathiTrust pages

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+
+# SFR HathiTrust Data Parser
+
+A function for parsing HathiTrust item records into a SFR-compliant data model. This reads data from spreadsheets made available through the [Hathifiles Page](https://www.hathitrust.org/hathifiles). Each file contains the previous days updates, which are put into the SFR data ingest Kinesis stream, for processing into the database and search index.
+
+## Version
+
+v0.0.1
+
+## Requirements
+
+Python 3.6+ (written with Python 3.7)
+
+## Dependencies
+
+- coverage
+- flake8
+- python-lambda
+- python-levenshtein
+- pyyaml
+
+## Note
+
+This function is based on the [Python Lambda Boilerplate](https://github.com/NYPL/python-lambda-boilerplate) and can be run/development with the help of the `make` commands made available through that repository.
+
+## Environment Variables
+
+- LOG_LEVEL
+
+## Event Triggers
+
+This function can be trigged through a CloudWatch event to run at a regularly scheduled interval (likely every 24 hours given the frequency of published updates from HathiTrust), or can be trigger to run locally with a provided CSV file. This mode of operation is useful for testing or ensuring that specific HathiTrust records are up to date in the SFR collection. The event required to trigger this manual operation should be a JSON document formatted as follows:
+
+``` JSON
+{
+    "source": "local.file",
+    "localFile": "/path/to/csv_file"
+}
+```
+
+## Testing/Development
+
+It is recommended that local development and testing of this function be done in a virtual environment.
+
+Tests can be run via the `make test` and linting through `make lint` command and local execution (using a local CSV file) can be done with `make local-run`
+
+To deploy the function to a Lambda in you AWS environment run `make deploy ENV=[environment]` where environment designates the desired YAML file you'd like to deploy with.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,36 @@
+region: us-east-1
+
+function_name: sfr-hathitrust-ingest
+handler: service.handler
+description: Read records from HathiTrust CSV dump files and transform into SFR-compatible format
+runtime: python3.6
+role: lambda_basic_execution
+
+# if access key and secret are left blank, boto will use the credentials
+# defined in the [default] section of ~/.aws/credentials.
+aws_access_key_id:
+aws_secret_access_key:
+
+# dist_directory: dist
+timeout: 30
+memory_size: 128
+
+# If tags are used they will overwrite all existing tags at deployment time
+#tags:
+# example: tag
+
+# Build options
+build:
+  source_directories: lib, helpers
+
+# Environment Variables
+# Any variables set here will be carried across all environments, unless
+# specifically overridden elsewhere. To set specific variables (for dev/qa/prod)
+# modify the individual .yaml files in the config directory
+# NOTE: The surrounding === comments enable the replacing and must be kept in
+# the file
+# === START_ENV_VARIABLES ===
+environment_variables:
+  ENV: local
+  LOG_LEVEL: info
+# === END_ENV_VARIABLES ===

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,0 +1,4 @@
+# Uncomment the below/add additional env variables to add them to the lambda
+# === ENVIRONMENT_VARIABLES ===
+environment_variables:
+    LOG_LEVEL: debug

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,0 +1,4 @@
+# Uncomment the below/add additional env variables to add them to the lambda
+# === ENVIRONMENT_VARIABLES ===
+environment_variables:
+    LOG_LEVEL: debug

--- a/helpers/clientHelpers.py
+++ b/helpers/clientHelpers.py
@@ -1,0 +1,31 @@
+import boto3
+
+from helpers.logHelpers import createLog
+from helpers.configHelpers import loadEnvFile
+
+logger = createLog('clientHelpers')
+
+
+def createAWSClient(service, configDict=None):
+
+    if configDict is None:
+        configDict, configLines = loadEnvFile(None, None)
+
+    clientKwargs = {
+        'region_name': configDict['region']
+    }
+
+    if (
+        'aws_access_key_id' in configDict
+        and
+        configDict['aws_access_key_id'] is not None
+    ):
+        clientKwargs['aws_access_key_id'] = configDict['aws_access_key_id']
+        clientKwargs['aws_secret_access_key'] = configDict['aws_secret_access_key']  # noqa: E501
+
+    lambdaClient = boto3.client(
+        service,
+        **clientKwargs
+    )
+
+    return lambdaClient

--- a/helpers/configHelpers.py
+++ b/helpers/configHelpers.py
@@ -1,0 +1,36 @@
+import yaml
+
+from helpers.logHelpers import createLog
+
+
+logger = createLog('configHelpers')
+
+
+def loadEnvFile(runType, fileString):
+
+    envDict = None
+    fileLines = []
+
+    if fileString:
+        openFile = fileString.format(runType)
+    else:
+        openFile = 'config.yaml'
+
+    try:
+        with open(openFile) as envStream:
+            try:
+                envDict = yaml.load(envStream)
+            except yaml.YAMLError as err:
+                logger.error('{} Invalid! Please review'.format(openFile))
+                raise err
+
+            envStream.seek(0)
+            fileLines = envStream.readlines()
+
+    except FileNotFoundError as err:
+        logger.info('Missing config YAML file! Check directory')
+        logger.debug(err)
+
+    if envDict is None:
+        envDict = {}
+    return envDict, fileLines

--- a/helpers/errorHelpers.py
+++ b/helpers/errorHelpers.py
@@ -1,0 +1,26 @@
+
+class NoRecordsReceived(Exception):
+    def __init__(self, message, invocation):
+        self.message = message
+        self.invocation = invocation
+
+
+class InvalidExecutionType(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+class ProcessingError(Exception):
+    def __init__(self, source, message):
+        self.source = source
+        self.message = message
+
+
+class DataError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+class KinesisError(Exception):
+    def __init__(self, message):
+        self.message = message

--- a/helpers/logHelpers.py
+++ b/helpers/logHelpers.py
@@ -1,0 +1,35 @@
+import logging
+import os
+
+levels = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warning': logging.WARNING,
+    'error': logging.ERROR,
+    'critical': logging.CRITICAL
+}
+
+
+def createLog(module):
+
+    logger = logging.getLogger(module)
+
+    if 'LOG_LEVEL' in os.environ:
+        checkLevel = os.environ['LOG_LEVEL'].lower()
+    else:
+        checkLevel = 'warning'
+
+    consoleLog = logging.StreamHandler()
+
+    if checkLevel in levels:
+        logger.setLevel(levels[checkLevel])
+        consoleLog.setLevel(levels[checkLevel])
+    else:
+        logger.setLevel(levels['warning'])
+        consoleLog.setLevel(levels['warning'])
+
+    formatter = logging.Formatter('%(asctime)s | %(name)s | %(levelname)s: %(message)s')  # noqa: E501
+    consoleLog.setFormatter(formatter)
+
+    logger.addHandler(consoleLog)
+    return logger

--- a/lib/countryParser.py
+++ b/lib/countryParser.py
@@ -1,0 +1,49 @@
+from lxml import etree
+
+from helpers.logHelpers import createLog
+from helpers.errorHelpers import ProcessingError
+
+logger = createLog('country_code_generator')
+
+
+def loadCountryCodes():
+    """HathiTrust records include publication places encoded in the MARC
+    country code format. These codes are accessed via an XML file from LOC that
+    provides the full-text versions of these country names. This function
+    generates a dict that correlates these codes with the full-text values,
+    which is used to translate the codes for use in SFR
+    """
+
+    countryTrans = {}
+
+    logger.info('Parsing country code/names dict from local file')
+
+    try:
+        countryXML = open('lib/marc_countries.xml')
+    except FileNotFoundError:
+        logger.error('Could find file at path {}'.format(
+            'lib/marc_countries.xml'
+        ))
+        raise ProcessingError(
+            'loadCountryCodes',
+            'Could not open marc_countries.xml'
+        )
+
+    with countryXML as countryXML:
+        countryTree = etree.parse(countryXML)
+        codeList = countryTree.getroot()
+        countries = codeList.find('{info:lc/xmlns/codelist-v1}countries')
+        for country in countries.findall('{info:lc/xmlns/codelist-v1}country'):
+            code = None
+            name = None
+            for child in country:
+                if child.tag == '{info:lc/xmlns/codelist-v1}code':
+                    code = child.text
+                elif child.tag == '{info:lc/xmlns/codelist-v1}name':
+                    name = child.text
+            logger.debug('Extracted country {} for code {}'.format(name, code))
+            countryTrans[code] = name
+
+    logger.info('Retrieved country names from lib/marc_countries.xml')
+
+    return countryTrans

--- a/lib/countryParser.py
+++ b/lib/countryParser.py
@@ -14,8 +14,6 @@ def loadCountryCodes():
     which is used to translate the codes for use in SFR
     """
 
-    countryTrans = {}
-
     logger.info('Parsing country code/names dict from local file')
 
     try:
@@ -32,18 +30,7 @@ def loadCountryCodes():
     with countryXML as countryXML:
         countryTree = etree.parse(countryXML)
         codeList = countryTree.getroot()
-        countries = codeList.find('{info:lc/xmlns/codelist-v1}countries')
-        for country in countries.findall('{info:lc/xmlns/codelist-v1}country'):
-            code = None
-            name = None
-            for child in country:
-                if child.tag == '{info:lc/xmlns/codelist-v1}code':
-                    code = child.text
-                elif child.tag == '{info:lc/xmlns/codelist-v1}name':
-                    name = child.text
-            logger.debug('Extracted country {} for code {}'.format(name, code))
-            countryTrans[code] = name
-
-    logger.info('Retrieved country names from lib/marc_countries.xml')
-
-    return countryTrans
+        
+        logger.info('Retrieving country names from lib/marc_countries.xml')
+        ns = '{info:lc/xmlns/codelist-v1}'
+        return dict([(c.find('{}code'.format(ns)).text, c.find('{}name'.format(ns)).text) for c in codeList.findall('.//{}country'.format(ns))])

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -55,7 +55,6 @@ class WorkRecord(DataObject):
         self.measurements = []
         self.dates = []
         self.uuid = None
-        self.license = None
         self.language = None
         self.title = None
         self.sub_title = None
@@ -63,7 +62,7 @@ class WorkRecord(DataObject):
         self.sort_title = None
         self.medium = None
         self.series = None
-        self.seriesPosition = None
+        self.series_position = None
         self.primary_identifier = None
         self.rights = None
 

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -1,0 +1,246 @@
+from helpers.errorHelpers import DataError
+
+
+class DataObject(object):
+    """Abstract data model object that specific classes inherit from. Sets
+    basic functions that allow writing/retrieving attributes."""
+
+    def __init__(self):
+        super()
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def getDictValue(self):
+        """Convert current object into a dict. Used for generating JSON objects
+        and in other instances where a standard type is necessary."""
+        return vars(self)
+
+    @classmethod
+    def createFromDict(cls, **kwargs):
+        """Take a standard dict object and convert to an instance of the
+        provided class. Allows for creation of new instances with arbitrary
+        fields set"""
+        record = cls()
+        for field, value in kwargs.items():
+            if field not in dir(record):
+                raise DataError('Field {} not valid for {}'.format(
+                    field,
+                    cls.__name__
+                ))
+            record[field] = value
+
+        return record
+
+    def addClassItem(self, listAttrib, classType, **identifierDict):
+        if listAttrib not in dir(self):
+            raise DataError('Field {} not valid for {}'.format(
+                listAttrib,
+                self.__class__.__name__
+            ))
+        self[listAttrib].append(classType.createFromDict(**identifierDict))
+
+
+class WorkRecord(DataObject):
+    def __init__(self):
+        super()
+        self.identifiers = []
+        self.instances = []
+        self.subjects = []
+        self.agents = []
+        self.links = []
+        self.measurements = []
+        self.dates = []
+        self.uuid = None
+        self.license = None
+        self.language = None
+        self.title = None
+        self.sub_title = None
+        self.alt_titles = None
+        self.sort_title = None
+        self.medium = None
+        self.series = None
+        self.seriesPosition = None
+        self.primary_identifier = None
+        self.rights = None
+
+    def __repr__(self):
+        dispTitle = self.title[:50] + '...' if self.title is not None and len(self.title) > 50 else self.title
+        primaryID = None if self.primary_identifier is None else self.primary_identifier.identifier
+        return '<Work(title={}, primary_id={})>'.format(
+            dispTitle,
+            primaryID
+        )
+
+
+class InstanceRecord(DataObject):
+    def __init__(self, title=None, language=None):
+        super()
+        self.title = title
+        self.language = language
+        self.sub_title = None
+        self.alt_titles = []
+        self.pub_place = None
+        self.edition = None
+        self.edition_statement = None
+        self.table_of_contents = None
+        self.agents = []
+        self.identifiers = []
+        self.formats = []
+        self.measurements = []
+        self.dates = []
+        self.rights = None
+
+    def __repr__(self):
+        dispTitle = self.title[:50] + '...' if self.title is not None and len(self.title) > 50 else self.title
+        return '<Instance(title={}, pub_place={})>'.format(
+            dispTitle,
+            self.pub_place
+        )
+
+
+class Format(DataObject):
+    def __init__(self, source=None, contentType=None, link=None, modified=None):
+        super()
+        self.source = source
+        self.content_type = contentType
+        self.modified = modified
+        self.drm = None
+        self.measurements = []
+        self.links = []
+        self.dates = []
+        self.agents = []
+        self.rights = None
+
+        if link is not None:
+            if (isinstance(link, Link)):
+                self.links.append(link)
+            else:
+                self.setLink(url=link)
+
+    def __repr__(self):
+        return '<Item(type={}, source={})>'.format(
+            self.content_type,
+            self.source
+        )
+
+    def setLink(self, **linkFields):
+        newLink = Link.createFromDict(**linkFields)
+        self.links.append(newLink)
+
+
+class Agent(DataObject):
+    def __init__(self, name=None, role=None, aliases=None, link=None):
+        super()
+        self.name = name
+        self.sort_name = None
+        self.lcnaf = None
+        self.viaf = None
+        self.biography = None
+        self.aliases = aliases
+        self.link = link
+        self.dates = []
+
+        if isinstance(role, (str, int)):
+            self.roles = [role]
+        else:
+            self.roles = role
+
+    def __repr__(self):
+        return '<Agent(name={}, roles={})>'.format(
+            self.name,
+            ', '.join(self.roles)
+        )
+
+
+class Identifier(DataObject):
+    def __init__(self, type=None, identifier=None, weight=None):
+        super()
+        self.type = type
+        self.identifier = identifier
+        self.weight = weight
+
+    def __repr__(self):
+        return '<Identifier(type={}, id={})>'.format(
+            self.type,
+            self.identifier
+        )
+
+
+class Link(DataObject):
+    def __init__(self, url=None, mediaType=None, relType=None):
+        super()
+        self.url = url
+        self.media_type = mediaType
+        self.content = None
+        self.rel_type = None
+        self.thumbnail = None
+
+    def __repr__(self):
+        return '<Link(url={}, type={})>'.format(self.url, self.media_type)
+
+
+class Subject(DataObject):
+    def __init__(self, subjectType=None, value=None, weight=None):
+        super()
+        self.authority = subjectType
+        self.subject = value
+        self.uri = None
+        self.weight = weight
+        self.measurements = []
+
+    def __repr__(self):
+        return '<Subject(authority={}, subject={})>'.format(
+            self.authority,
+            self.subject
+        )
+
+
+class Measurement(DataObject):
+    def __init__(self, quantity=None, value=None, weight=None, takenAt=None):
+        super()
+        self.quantity = quantity
+        self.value = value
+        self.weight = weight
+        self.taken_at = takenAt
+
+    def __repr__(self):
+        return '<Measurement(quantity={}, value={})>'.format(
+            self.quantity,
+            self.value
+        )
+
+    @staticmethod
+    def getValueForMeasurement(measurementList, quantity):
+        retMeasurement = list(filter(lambda x: x['quantity'] == quantity, measurementList))
+        return retMeasurement[0]['value']
+
+
+class Date(DataObject):
+    def __init__(self, displayDate=None, dateRange=None, dateType=None):
+        super()
+        self.display_date = displayDate
+        self.date_range = dateRange
+        self.date_type = dateType
+
+    def __repr__(self):
+        return '<Date(date={}, type={})>'.format(
+            self.display_date,
+            self.date_type
+        )
+
+
+class Rights(DataObject):
+    def __init__(self, source=None, license=None, statement=None, reason=None):
+        super()
+        self.source = source
+        self.license = license
+        self.rights_statement = statement
+        self.rights_reason = reason
+        self.dates = []
+
+    def __repr__(self):
+        return '<Rights(license={})>'.format(self.license)

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -108,6 +108,7 @@ class Format(DataObject):
         self.content_type = contentType
         self.modified = modified
         self.drm = None
+        self.identifiers = []
         self.measurements = []
         self.links = []
         self.dates = []

--- a/lib/hathiRecord.py
+++ b/lib/hathiRecord.py
@@ -295,7 +295,7 @@ class HathiRecord():
         workIdentifiers = [
             ('hathi', 'bib_key'),
             ('hathi', 'htid'),
-            ('generic', 'source_id'),
+            (None, 'source_id'),
             ('isbn', 'isbns'),
             ('issn', 'issns'),
             ('lccn', 'lccns'),
@@ -339,7 +339,7 @@ class HathiRecord():
         # Instances and works will share many identifiers
         instanceIdentifiers = [
             ('hathi', 'htid'),
-            ('generic', 'source_id'),
+            (None, 'source_id'),
             ('isbn', 'isbns'),
             ('issn', 'issns'),
             ('lccn', 'lccns'),
@@ -373,6 +373,14 @@ class HathiRecord():
         logger.info('Creating item record for instance {}'.format(
             self.instance
         ))
+
+        # Items will generally only be identified by their hathi ID
+        itemIdentifiers = [
+            ('hathi', 'htid'),
+        ]
+        for idType, key in itemIdentifiers:
+            logger.debug('Setting item identifiers {}'.format(idType))
+            self.parseIdentifiers(self.item, idType, key)
 
         logger.debug('Storing direct and download links based on htid {}'.format(self.ingest['htid']))
         # The link to the external HathiTrust page

--- a/lib/hathiRecord.py
+++ b/lib/hathiRecord.py
@@ -1,0 +1,582 @@
+import re
+from datetime import datetime
+
+from lib.dataModel import (
+    WorkRecord,
+    Identifier,
+    InstanceRecord,
+    Format,
+    Rights,
+    Agent,
+    Measurement,
+    Date,
+    Link
+)
+
+from helpers.logHelpers import createLog
+
+logger = createLog('hathiRecord')
+
+
+class HathiRecord():
+    """Class for constructing HathiTrust-based records in the SFR data model.
+    This largely serves as a wrapper for classes imported from the SFR model,
+    and includes functions that can build these up. It also contains several
+    class-level lookup tables for codes/values provided in the Hathi CSV files.
+    """
+
+    # These codes are supplied by Hathi as the determination of an item's
+    # rights status.
+    rightsReasons = {
+        'bib': 'bibliographically-dervied by automatic processes',
+        'ncn': 'no printed copyright notice',
+        'con': 'contractual agreement with copyright holder on file',
+        'ddd': 'due diligence documentation on file',
+        'man': 'manual access control override; see note for details',
+        'pvt': 'private personal information visible',
+        'ren': 'copyright renewal research was conducted',
+        'nfi': 'needs further investigation (copyright research partially complete)',
+        'cdpp': 'title page or verso contain copyright date and/or place of publication information not in bib record',
+        'ipma': 'in-print and market availability research was conducted',
+        'unp': 'unpublished work',
+        'gfv': 'Google viewability set at VIEW_FULL',
+        'crms': 'derived from multiple reviews in the Copyright Review Management System',
+        'add': 'author death date research was conducted or notification was received from authoritative source',
+        'exp': 'expiration of copyright term for non-US work with corporate author',
+        'del': 'deleted from the repository; see not for details',
+        'gatt': 'non-US public domain work restroted to in-copyright in the US by GATT',
+        'supp': 'suppressed from view; see note for details'
+    }
+
+    # Decodes rights statements into full licenses (CreativeCommons links where
+    # possible), and human-readable statements.
+    rightsValues = {
+        'pd': {
+            'license': 'public_domain',
+            'statement': 'Public Domain'
+        },
+        'ic': {
+            'license': 'in_copyright',
+            'statement': 'In Copyright'
+        },
+        'op': {
+            'license': 'in_copyright (out_of_print)',
+            'statement': 'Out of Print (implied to be in copyright)'
+        },
+        'orph': {
+            'license': 'in_copyright (orphaned)',
+            'statement': 'Copyright Orphaned (implied to be in copyright)'
+        },
+        'und': {
+            'license': 'undetermined',
+            'statement': 'Status Undetermined'
+        },
+        'ic-world': {
+            'license': 'in_copyright (viewable)',
+            'statement': 'In Copyright, permitted to be world viewable'
+        },
+        'nobody': {
+            'license': 'in_copyright (blocked)',
+            'statement': 'Blocked for all users'
+        },
+        'pdus': {
+            'license': 'public_domain (us_only)',
+            'statement': 'Public Domain when viewed in the US'
+        },
+        'cc-by-3.0': {
+            'license': 'https://creativecommons.org/licenses/by/3.0/',
+            'statement': 'Creative Commons Attribution License, 3.0 Unported'
+        },
+        'cc-by-nd-3.0': {
+            'license': 'https://creativecommons.org/licenses/by-nd/3.0/',
+            'statement': 'Creative Commons Attribution, No Derivatives License, 3.0 Unported'
+        },
+        'cc-by-nc-nd-3.0': {
+            'license': 'https://creativecommons.org/licenses/by-nc-nd/3.0/',
+            'statement': 'Creative Commons Attribution, Non-Commercial, Share Alike License, 3.0 Unported'
+        },
+        'cc-by-sa-3.0': {
+            'license': 'https://creativecommons.org/licenses/by-sa/3.0/',
+            'statement': 'Creative Commons Attribution, Share Alike License, 3.0 Unported'
+        },
+        'orphcand': {
+            'license': 'in_copyright (90-day hold)',
+            'statement': 'Orphan Candidate - in 90-day holding period'
+        },
+        'cc-zero': {
+            'license': 'https://creativecommons.org/publicdomain/zero/1.0/',
+            'statement': 'Creative Commons Universal Public Domain'
+        },
+        'und-world': {
+            'license': 'undetermined',
+            'statement': 'Copyright Status undetermined, world viewable'
+        },
+        'icus': {
+            'license': 'in_copyright (in US)',
+            'statement': 'In Copyright in the US'
+        },
+        'cc-by-4.0': {
+            'license': 'https://creativecommons.org/licenses/by/4.0/',
+            'statement': 'Creative Commons Attribution 4.0 International License'
+        },
+        'cc-by-nd-4.0': {
+            'license': 'https://creativecommons.org/licenses/by-nd/4.0/',
+            'statement': 'Creative Commons Attribution, No Derivatives 4.0 International License'
+        },
+        'cc-by-nc-nd-4.0': {
+            'license': 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+            'statement': 'Creative Commons Attribution, Non-Commercial, No Derivatives 4.0 International License'
+        },
+        'cc-by-nc-4.0': {
+            'license': 'https://creativecommons.org/licenses/by-nc/4.0/',
+            'statement': 'Creative Commons Attribution, Non-Commercial 4.0 International License'
+        },
+        'cc-by-nc-sa-4.0': {
+            'license': 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+            'statement': 'Creative Commons Attribution, Non-Commercial, Share Alike 4.0 International License'
+        },
+        'cc-by-sa-4.0': {
+            'license': 'https://creativecommons.org/licenses/by-sa/4.0/',
+            'statement': 'Creative Commons Attribution, Share Alike 4.0 International License'
+        },
+        'pd-pvt': {
+            'license': 'public_domain (privacy_limited)',
+            'statement': 'Public Domain access limited for privacy concerns'
+        },
+        'supp': {
+            'license': 'suppressed',
+            'statement': 'Suppressed from view'
+        }
+    }
+
+    # List of institution codes for organizations that have contributed
+    # materials to HathiTrust
+    sourceCodes = {
+        'aub': 'American University of Beirut',
+        'bc': 'Boston College',
+        'columbia': 'Columbia University',
+        'cornell': 'Cornell University',
+        'duke': 'Duke University',
+        'emory': 'Emory University',
+        'flbog': 'State University System of Florida',
+        'getty': 'Getty Research Institute',
+        'harvard': 'Harvard University',
+        'hathitrust': 'HathiTrust',
+        'illinois': 'University of Illinois at Urbana-Champaign',
+        'iu': 'Indiana University',
+        'loc': 'Library of Congress',
+        'mcgill': 'McGill University',
+        'missouri': 'University of Missouri-Columbia',
+        'msu': 'Michigan State University',
+        'ncsu': 'North Carolina State University',
+        'nd': 'University of Notre Dame',
+        'northwestern': 'Northwestern University',
+        'nypl': 'New York Public Library',
+        'osu': 'The Ohio State University',
+        'princeton': 'Princeton University',
+        'psu': 'Pennsylvania State University',
+        'purdue': 'Purdue University',
+        'tamu': 'Texas A&M',
+        'tufts': 'Tufts University',
+        'ualberta': 'University of Alberta',
+        'uchicago': 'University of Chicago',
+        'ucm': 'University of California, Merced',
+        'uconn': 'University of Connecticut',
+        'udel': 'University of Delaware',
+        'uiowa': 'University of Iowa',
+        'umass': 'University of Massachusetts',
+        'umd': 'University of Maryland',
+        'umich': 'University of Michigan',
+        'umn': 'University of Minnesota',
+        'unc': 'University of North Carolina',
+        'universityofcalifornia': 'University of California',
+        'upenn': 'University of Pennsylvania',
+        'uq': 'The University of Queensland',
+        'usu': 'Utah State University',
+        'utexas': 'University of Texas',
+        'virginia': 'University of Virginia',
+        'washington': 'University of Washington',
+        'wfu': 'Wake Forest University',
+        'wisc': 'University of Wisconsin',
+        'yale': 'Yale University',
+    }
+
+    # List of organizations that have digitized materials in HathiTrust
+    digCodes = {
+        'google': 'Google',
+        'lit-dlps-dc': 'Library IT, Digital Library Production Service, Digital Conversion',
+        'ump': 'University of Michigan Press',
+        'ia': 'Internet Archive',
+        'yale': 'Yale University',
+        'mdl': 'Minnesota Digital Library',
+        'mhs': 'Minnesota Historical Society',
+        'usup': 'Utah State University Press',
+        'ucm': 'Universidad Complutense de Madrid',
+        'purd': 'Purdue University',
+        'getty': 'Getty Research Institute',
+        'um-dc-mp': 'University of Michigan, Duderstadt Center, Millennium Project',
+        'uiuc': 'University of Illinois at Urbana-Champaign',
+        'illinois': 'University of Illinois at Urbana-Champaign',
+        'brooklynmuseum': 'Brooklyn Museum',
+        'uf': 'State University of Florida',
+        'tamu': 'Texas A&M',
+        'udel': 'University of Delaware',
+        'private': 'Private Donor',
+        'umich': 'University of Michigan',
+        'clark': 'Clark Art Institute',
+        'ku': 'Knowledge Unlatched',
+        'mcgill': 'McGill University',
+        'bc': 'Boston College',
+        'nnc': 'Columbia University',
+        'geu': 'Emory University',
+        'yale2': 'Yale University',
+        'mou': 'University of Missouri-Columbia',
+        'chtanc': 'National Central Library of Taiwan',
+        'bentley-umich': 'Bentley Historical Library, University of Michigan',
+        'clements-umich': 'William L. Clements Library, University of Michigan',
+        'wau': 'University of Washington',
+        'cornell': 'Cornell University',
+        'cornell-ms': 'Cornell University/Microsoft',
+        'umd': 'University of Maryland',
+        'frick': 'The Frick Collection',
+        'northwestern': 'Northwestern University',
+        'umn': 'University of Minnesota',
+        'berkeley': 'University of California, Berkeley',
+        'ucmerced': 'University of California, Merced',
+        'nd': 'University of Notre Dame',
+        'princeton': 'Princeton University',
+        'uq': 'The University of Queensland',
+        'ucla': 'University of California, Los Angeles',
+        'osu': 'The Ohio State University',
+        'upenn': 'University of Pennsylvania',
+        'aub': 'American University of Beirut',
+        'ucsd': 'University of California, San Diego',
+        'harvard': 'Harvard University',
+        'borndigital': None,
+    }
+
+    def __init__(self, ingestRecord, ingestDateTime=None):
+        # Initialize with empty SFR data objects
+        # self.ingest contains the source data
+        self.work = WorkRecord()
+        self.ingest = ingestRecord
+        self.instance = InstanceRecord()
+        self.item = Format()
+        self.rights = Rights()
+        self.modified = ingestDateTime
+        logger.debug('Initializing empty HathiRecord object')
+
+        # We need a fallback modified date if none is provided
+        if self.modified is None:
+            self.modified = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            logger.debug('Assigning generated timestamp of {} to new record'.format(self.modified))
+        elif type(self.modified) is datetime:
+            self.modified = self.modified.strftime('%Y-%m-%d %H:%M:%S')
+
+    def __repr__(self):
+        return '<Hathi(title={})>'.format(self.work.title)
+
+    def buildWork(self):
+        """Construct the SFR Work object from the Hathi data"""
+        self.work.title = self.ingest['title']
+        self.work.series = self.ingest['description']
+        logger.info('Creating work record for {}'.format(self.work.title))
+        # The primary identifier for this work is a HathiTrust bib reference
+        self.work.primary_identifier = Identifier(
+            type='hathi',
+            identifier=self.ingest['bib_key'],
+            weight=1
+        )
+        logger.debug('Setting primary_identifier to {}'.format(
+            self.work.primary_identifier
+        ))
+
+        # Identifiers are included across multiple columns
+        workIdentifiers = [
+            ('hathi', 'bib_key'),
+            ('hathi', 'htid'),
+            ('generic', 'source_id'),
+            ('isbn', 'isbns'),
+            ('issn', 'issns'),
+            ('lccn', 'lccns'),
+            ('oclc', 'oclcs')
+        ]
+        for idType, key in workIdentifiers:
+            logger.debug('Setting identifiers {}'.format(idType))
+            self.parseIdentifiers(self.work, idType, key)
+
+        # All government documents should be in the public_domain.
+        self.parseGovDoc(self.ingest['gov_doc'])
+
+        # The copyright date assigned to the work by HathiTrust
+        self.work.addClassItem('dates', Date, **{
+            'display_date': self.ingest['copyright_date'],
+            'date_range': self.ingest['copyright_date'],
+            'date_type': 'copyright_date'
+        })
+        logger.debug('Setting copyright date to {}'.format(
+            self.ingest['copyright_date']
+        ))
+
+        self.parseAuthor(self.ingest['author'])
+
+    def buildInstance(self, countryCodes):
+        """Constrict an instance record from the Hathi data provided. As
+        structured Hathi trust data will always correspond to a single
+        instance. A wok in Hathi can have multiple items, and this relationship
+        is reflected in the data.
+
+        We do not attempt to merge records at this phase, but will associated
+        works and instances related by identifiers when stored in the database.
+        """
+        self.instance.title = self.ingest['title']
+        self.instance.language = self.ingest['language']
+
+        logger.info('Creating instance record for work {}'.format(self.work))
+
+        self.parsePubPlace(self.ingest['pub_place'], countryCodes)
+
+        # Instances and works will share many identifiers
+        instanceIdentifiers = [
+            ('hathi', 'htid'),
+            ('generic', 'source_id'),
+            ('isbn', 'isbns'),
+            ('issn', 'issns'),
+            ('lccn', 'lccns'),
+            ('oclc', 'oclcs')
+        ]
+        for idType, key in instanceIdentifiers:
+            logger.debug('Setting identifiers {}'.format(idType))
+            self.parseIdentifiers(self.instance, idType, key)
+
+        self.instance.addClassItem('dates', Date, **{
+            'display_date': self.ingest['copyright_date'],
+            'date_range': self.ingest['copyright_date'],
+            'date_type': 'copyright_date'
+        })
+        logger.debug('Setting copyright date to {}'.format(
+            self.ingest['copyright_date']
+        ))
+
+        self.parsePubInfo(self.ingest['publisher_pub_date'])
+
+    def buildItem(self):
+        """HathiTrust items also correspond to a single item, the digitzed
+        version of the book being described. From this record we can derive two
+        links, a link to the HathiTrust reader page and a page for a direct
+        download of the PDF copy of the book.
+        """
+        self.item.source = 'hathitrust'
+        self.item.content_type = 'ebook'
+        self.item.modified = self.modified
+
+        logger.info('Creating item record for instance {}'.format(
+            self.instance
+        ))
+
+        logger.debug('Storing direct and download links based on htid {}'.format(self.ingest['htid']))
+        # The link to the external HathiTrust page
+        self.item.addClassItem('links', Link, **{
+            'url': 'https://babel.hathitrust.org/cgi/pt?id={}'.format(self.ingest['htid']),
+            'media_type': 'text/html',
+            'rel_type': 'external_view'
+        })
+
+        # The link to the direct PDF download
+        self.item.addClassItem('links', Link, **{
+            'url': 'https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={}'.format(self.ingest['htid']),
+            'media_type': 'application/pdf',
+            'rel_type': 'pdf_download'
+        })
+
+        logger.debug('Storing repository {} as agent'.format(self.ingest['source']))
+        self.item.addClassItem('agents', Agent, **{
+            'name': self.ingest['source'],
+            'roles': ['repository']
+        })
+
+        logger.debug('Storing organization {} as agent'.format(
+            self.ingest['responsible_entity']
+        ))
+        self.item.addClassItem('agents', Agent, **{
+            'name': HathiRecord.sourceCodes[self.ingest['responsible_entity']],
+            'roles': ['responsible_organization']
+        })
+
+        logger.debug('Storing digitizer {} as agent'.format(
+            self.ingest['digitization_entity']
+        ))
+        self.item.addClassItem('agents', Agent, **{
+            'name': HathiRecord.digCodes[self.ingest['digitization_entity']],
+            'roles': ['digitizer']
+        })
+
+    def createRights(self):
+        """HathiTrust contains a strong set of rights data per item, including
+        license, statement and justification fields. As this metadata is
+        applicable to all levels in the SFR model, constructing a stand-alone
+        rights object is the best way to ensure that accurate rights data
+        is assigned to the records extracted from HathiTrust.
+        """
+
+        logger.info('Creating new rights object for row {}'.format(
+            self.ingest['htid']
+        ))
+
+        self.rights.source = 'hathi_trust'
+        self.rights.license = HathiRecord.rightsValues[self.ingest['rights']]['license']
+        self.rights.rights_statement = HathiRecord.rightsValues[self.ingest['rights']]['statement']
+        self.rights.rights_reason = HathiRecord.rightsReasons[self.ingest['rights_statement']]
+
+        self.rights.addClassItem('dates', Date, **{
+            'display_date': self.ingest['rights_determination_date'],
+            'date_range': self.ingest['rights_determination_date'],
+            'date_type': 'determination_date'
+        })
+
+        self.rights.addClassItem('dates', Date, **{
+            'display_date': self.ingest['copyright_date'],
+            'date_range': self.ingest['copyright_date'],
+            'date_type': 'copyright_date'
+        })
+
+    def parseIdentifiers(self, record, idType, key):
+        """Iterate identifiers, splitting multiple values and storing in
+        the indicated record.
+        """
+        if key not in self.ingest:
+            logger.warning('{} not a valid type of identifier'.format(key))
+            return
+        idInstances = self.ingest[key].split(',')
+        if len(idInstances) >= 1 and idInstances[0] != '':
+            for typeInst in idInstances:
+                logger.debug('Storing identifier {} ({}) for {}'.format(
+                    typeInst,
+                    idType,
+                    record
+                ))
+                record.addClassItem('identifiers', Identifier, **{
+                    'type': idType,
+                    'identifier': typeInst.strip(),
+                    'weight': 1
+                })
+
+    def parseAuthor(self, authorStr):
+        """Hathi data files include an author column that combines author name
+        with their birth and death dates (sometimes). This method parses
+        those dates from the name and assigns them as Date objects to the
+        constructed agent record. This record is then assigned to the work.
+        """
+        logger.info('Storing author {} for work {}'.format(
+            authorStr,
+            self.work
+        ))
+        authorDateGroup = re.search(r'([0-9\-c?\'.]{4,})', authorStr)
+        authorDates = None
+        if authorDateGroup is not None:
+            authorDates = authorDateGroup.group(1)
+            authorName = authorStr.replace(authorDates, '').strip(' ,.')
+            logger.debug('Found lifespan dates {}'.format(authorDates))
+        else:
+            authorName = authorStr
+            logger.debug('Found no lifespan dates')
+
+        authorRec = Agent(
+            name=authorName,
+            role='author'
+        )
+
+        if authorDates is not None:
+            logger.info('Creating date objects for author lifespan')
+            lifespan = authorDates.strip(' ,.').split('-')
+            if len(lifespan) == 1:
+                logger.debug('Found single date, default to death_date')
+                dateType = 'death_date'
+                datePrefix = re.search(r' b(?: |\.)', authorStr)
+                if datePrefix is not None:
+                    authorRec.name = re.sub(r' b(?: |\.|$)', '', authorName).strip(' ,.')
+                    logger.debug('Detected single birth_date (living author)')
+                    dateType = 'birth_date'
+
+                logger.debug('Storing single date {} of type {}'.format(
+                    lifespan[0],
+                    dateType
+                ))
+                authorRec.addClassItem('dates', Date, **{
+                    'display_date': lifespan[0],
+                    'date_range': lifespan[0],
+                    'date_type': dateType
+                })
+
+            else:
+                logger.debug('Storing lifespan {}-{} as dates'.format(
+                    lifespan[0],
+                    lifespan[1]
+                ))
+                authorRec.addClassItem('dates', Date, **{
+                    'display_date': lifespan[0],
+                    'date_range': lifespan[0],
+                    'date_type': 'birth_date'
+                })
+                authorRec.addClassItem('dates', Date, **{
+                    'display_date': lifespan[1],
+                    'date_range': lifespan[1],
+                    'date_type': 'death_date'
+                })
+        logger.debug('Appending agent record {} to work'.format(authorRec))
+        self.work.agents.append(authorRec)
+
+    def parsePubPlace(self, pubPlace, countryCodes):
+        """Attempt to load a country/state name from the countryCodes list
+        If not found simply include the code as the publication place
+        NOTE: If this occurs frequently check the MARC site for an updated
+        list and issue a pull request to replace the XML included here.
+        """
+        try:
+            self.instance.pub_place = countryCodes[pubPlace.strip()]
+            logger.debug('Setting decoded pub_place to {}'.format(
+                self.instance.pub_place
+            ))
+        except KeyError:
+            self.instance.pub_place = pubPlace.strip()
+            logger.warning('Failed to decode pub_place code, setting to raw code {}'.format(self.instance.pub_place))
+
+    def parsePubInfo(self, imprintInfo):
+        """Similar to authors 'imprint' or publication info is combined into
+        a single column. This extracts the date and attempts to clean up
+        any trailing punctuation left over from this operation.
+        """
+        logger.info('Storing publication {} info for instance {}'.format(
+            imprintInfo,
+            self.instance
+        ))
+        pubDateGroup = re.search(r'([0-9\-c?\'.]{4,})', imprintInfo)
+        if pubDateGroup is not None:
+            pubDate = pubDateGroup.group(1).strip(' ,.')
+            logger.debug('Storing publication date {}'.format(pubDate))
+            self.instance.addClassItem('dates', Date, **{
+                'display_date': pubDate,
+                'date_range': pubDate,
+                'date_type': 'publication_date'
+            })
+            imprintInfo = imprintInfo.replace(pubDate, '')
+
+        imprintInfo = re.sub(r'[\W]{2,}$', '', imprintInfo)
+        logger.debug('Storing publisher as agent {}'.format(imprintInfo))
+        self.instance.addClassItem('agents', Agent, **{
+            'name': imprintInfo,
+            'roles': ['publisher']
+        })
+
+    def parseGovDoc(self, govDocStatus):
+        if str(govDocStatus).lower() in ['1', 't']:
+            govDocStatus = True
+        else:
+            govDocStatus = False
+        self.work.addClassItem('measurements', Measurement, **{
+            'quantity': 'government_document',
+            'value': int(govDocStatus),
+            'weight': 1,
+            'taken_at': datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        })
+        logger.debug('Storing gov_doc status to {}'.format(str(govDocStatus)))

--- a/lib/kinesisWrite.py
+++ b/lib/kinesisWrite.py
@@ -1,0 +1,37 @@
+import json
+import os
+
+from helpers.errorHelpers import KinesisError
+from helpers.logHelpers import createLog
+from helpers.clientHelpers import createAWSClient
+
+logger = createLog('kinesis_write')
+
+
+class KinesisOutput():
+    """Class for managing connections and operations with AWS Kinesis"""
+    KINESIS_CLIENT = createAWSClient('kinesis')
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def putRecord(cls, outputObject, stream):
+        """Put an event into the specific Kinesis stream"""
+        logger.info('Writing results to Kinesis')
+
+        # The default lambda function here converts all objects into dicts
+        kinesisStream = json.dumps(
+            outputObject,
+            ensure_ascii=False,
+            default=lambda x: vars(x)
+        )
+        try:
+            cls.KINESIS_CLIENT.put_record(
+                StreamName=stream,
+                Data=kinesisStream,
+                PartitionKey=os.environ['OUTPUT_SHARD']
+            )
+        except:
+            logger.error('Kinesis Write error!')
+            raise KinesisError('Failed to write result to output stream!')

--- a/lib/marc_countries.xml
+++ b/lib/marc_countries.xml
@@ -1,0 +1,5101 @@
+<codelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="info:lc/xmlns/codelist-v1" version="1.0" xsi:schemaLocation="info:lc/xmlns/codelist-v1 http://www.loc.gov/standards/codelists/codelist.xsd">
+<codelistId>marccountry</codelistId>
+<title>MARC Code List for Countries</title>
+<author>
+Network Development and MARC Standards Office, Library of Congress
+</author>
+<uri>info:lc/vocabulary/countries</uri>
+<countries>
+<country>
+<uri>info:lc/vocabulary/countries/af</uri>
+<name authorized="yes">Afghanistan</name>
+<code>af</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/alu</uri>
+<name authorized="yes">Alabama</name>
+<code>alu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/aku</uri>
+<name authorized="yes">Alaska</name>
+<code>aku</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/aa</uri>
+<name authorized="yes">Albania</name>
+<code>aa</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/abc</uri>
+<name authorized="yes">Alberta</name>
+<code>abc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ae</uri>
+<name authorized="yes">Algeria</name>
+<code>ae</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/as</uri>
+<name authorized="yes">American Samoa</name>
+<code>as</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Eastern Samoa</name>
+</uf>
+<uf>
+<name>Samoa, American</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/an</uri>
+<name authorized="yes">Andorra</name>
+<code>an</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ao</uri>
+<name authorized="yes">Angola</name>
+<code>ao</code>
+<region>Africa</region>
+<uf>
+<name>Cabinda</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/am</uri>
+<name authorized="yes">Anguilla</name>
+<code>am</code>
+<region>West Indies</region>
+<code status="obsolete" date="198803">ai</code>
+<note>
+<name>Saint Kitts-Nevis-Anguilla</name>
+<code status="obsolete">xi</code>
+<date type="before">19850101</date>
+</note>
+<uf>
+<name>Saint Kitts-Nevis-Anguilla</name>
+<note>
+<name>Saint Kitts-Nevis-Anguilla</name>
+<code status="obsolete">xi</code>
+<date type="before">198501</date>
+</note>
+</uf>
+<uf>
+<name>Sombrero Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ay</uri>
+<name authorized="yes">Antarctica</name>
+<code>ay</code>
+<region>Other</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/aq</uri>
+<name authorized="yes">Antigua and Barbuda</name>
+<code>aq</code>
+<region>West Indies</region>
+<uf>
+<name>Antigua</name>
+</uf>
+<uf>
+<name>Barbuda</name>
+</uf>
+<uf>
+<name>Redonda</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ag</uri>
+<name authorized="yes">Argentina</name>
+<code>ag</code>
+<region>South America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/azu</uri>
+<name authorized="yes">Arizona</name>
+<code>azu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/aru</uri>
+<name authorized="yes">Arkansas</name>
+<code>aru</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ai</uri>
+<name authorized="yes">Armenia (Republic)</name>
+<code>ai</code>
+<region>Asia</region>
+<note>
+<name>Armenian S.S.R.</name>
+<code status="obsolete">air</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Armenian S.S.R.</name>
+<note>
+<name>Armenian S.S.R.</name>
+<code status="obsolete">air</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/aw</uri>
+<name authorized="yes">Aruba</name>
+<code>aw</code>
+<region>West Indies</region>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">198803</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/at</uri>
+<name authorized="yes">Australia</name>
+<code>at</code>
+<region>Australasia</region>
+<uf>
+<name>Ashmore and Cartier Islands</name>
+<note>
+<name>Ashmore and Cartier Islands</name>
+<code status="obsolete">ac</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Macquarie Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/aca</uri>
+<name authorized="yes">Australian Capital Territory</name>
+<code>aca</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/au</uri>
+<name authorized="yes">Austria</name>
+<code>au</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/aj</uri>
+<name authorized="yes">Azerbaijan</name>
+<code>aj</code>
+<region>Asia</region>
+<note>
+<name>Azerbaijan S.S.R.</name>
+<code status="obsolete">ajr</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Azerbaijan S.S.R.</name>
+<note>
+<name>Azerbaijan S.S.R. </name>
+<code status="obsolete">ajr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bf</uri>
+<name authorized="yes">Bahamas</name>
+<code>bf</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ba</uri>
+<name authorized="yes">Bahrain</name>
+<code>ba</code>
+<region>Asia</region>
+<uf>
+<name>Bahrein</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bg</uri>
+<name authorized="yes">Bangladesh</name>
+<code>bg</code>
+<region>Asia</region>
+<uf>
+<name>East Pakistan</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bb</uri>
+<name authorized="yes">Barbados</name>
+<code>bb</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bw</uri>
+<name authorized="yes">Belarus</name>
+<code>bw</code>
+<region>Europe</region>
+<note>
+<name>Byelorussian S.S.R</name>
+<code status="obsolete">bwr</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Byelarus</name>
+</uf>
+<uf>
+<name>Belorussian S.S.R.</name>
+</uf>
+<uf>
+<name>Byeolorussian S.S.R.</name>
+<note>
+<name>Byelorussian S.S.R.</name>
+<code status="obsolete">bwr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/be</uri>
+<name authorized="yes">Belgium</name>
+<code>be</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bh</uri>
+<name authorized="yes">Belize</name>
+<code>bh</code>
+<region>Central America</region>
+<uf>
+<name>British Honduras</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/dm</uri>
+<name authorized="yes">Benin</name>
+<code>dm</code>
+<region>Africa</region>
+<uf>
+<name>Dahomey</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bm</uri>
+<name authorized="yes">Bermuda Islands</name>
+<code>bm</code>
+<region>Atlantic Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bt</uri>
+<name authorized="yes">Bhutan</name>
+<code>bt</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bo</uri>
+<name authorized="yes">Bolivia</name>
+<code>bo</code>
+<region>South America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bn</uri>
+<name authorized="yes">Bosnia and Herzegovina</name>
+<code>bn</code>
+<region>Europe</region>
+<note>
+<name>Yugoslavia</name>
+<code status="obsolete">yu</code>
+<date type="before">199210</date>
+</note>
+<uf>
+<name>Bosnia and Hercegovina</name>
+</uf>
+<uf>
+<name>Hercegovina</name>
+</uf>
+<uf>
+<name>Herzegovina</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bs</uri>
+<name authorized="yes">Botswana</name>
+<code>bs</code>
+<region>Africa</region>
+<uf>
+<name>Bechuanaland</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bv</uri>
+<name authorized="yes">Bouvet Island</name>
+<code>bv</code>
+<region>Atlantic Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bl</uri>
+<name authorized="yes">Brazil</name>
+<code>bl</code>
+<region>South America</region>
+<uf>
+<name>Fernando de Noronha</name>
+</uf>
+<uf>
+<name>Ilha da Trindade</name>
+</uf>
+<uf>
+<name>Ilhas Martim Vaz</name>
+</uf>
+<uf>
+<name>Martim Vaz, Ilhas</name>
+</uf>
+<uf>
+<name>Penedos de São Pedro e São Paulo</name>
+</uf>
+<uf>
+<name>Rocas</name>
+</uf>
+<uf>
+<name>Trindade, Ilha da</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bcc</uri>
+<name authorized="yes">British Columbia</name>
+<code>bcc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bi</uri>
+<name authorized="yes">British Indian Ocean Territory</name>
+<code>bi</code>
+<region>Indian Ocean</region>
+<uf>
+<name>Chagos Archipelago</name>
+</uf>
+<uf>
+<name>Diego Garcia Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/vb</uri>
+<name authorized="yes">British Virgin Islands</name>
+<code>vb</code>
+<region>West Indies</region>
+<uf>
+<name>Anegada</name>
+</uf>
+<uf>
+<name>Colony of the Virgin Islands</name>
+</uf>
+<uf>
+<name>Jost Van Dyke</name>
+</uf>
+<uf>
+<name>Tortola</name>
+</uf>
+<uf>
+<name>Virgin Gorda</name>
+</uf>
+<uf>
+<name>Virgin Islands (British)</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bx</uri>
+<name authorized="yes">Brunei</name>
+<code>bx</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bu</uri>
+<name authorized="yes">Bulgaria</name>
+<code>bu</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/uv</uri>
+<name authorized="yes">Burkina Faso</name>
+<code>uv</code>
+<region>Africa</region>
+<uf>
+<name>Upper Volta</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/br</uri>
+<name authorized="yes">Burma</name>
+<code>br</code>
+<region>Asia</region>
+<uf>
+<name>Myanmar</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bd</uri>
+<name authorized="yes">Burundi</name>
+<code>bd</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cau</uri>
+<name authorized="yes">California</name>
+<code>cau</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cb</uri>
+<name authorized="yes">Cambodia</name>
+<code>cb</code>
+<region>Asia</region>
+<uf>
+<name>Democratic Kampuchea</name>
+</uf>
+<uf>
+<name>Kampuchea</name>
+</uf>
+<uf>
+<name>Khmer Republic</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cm</uri>
+<name authorized="yes">Cameroon</name>
+<code>cm</code>
+<region>Africa</region>
+<uf>
+<name>British Cameroons</name>
+</uf>
+<uf>
+<name>East Cameroon</name>
+</uf>
+<uf>
+<name>French Cameroons</name>
+</uf>
+<uf>
+<name>German Cameroons</name>
+</uf>
+<uf>
+<name>Southern Cameroons</name>
+</uf>
+<uf>
+<name>West Cameroon</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xxc</uri>
+<name authorized="yes">Canada</name>
+<code>xxc</code>
+<region>North America</region>
+<note>
+<name>Canada</name>
+<code status="obsolete">cn</code>
+<date type="before">198803</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cv</uri>
+<name authorized="yes">Cabo Verde</name>
+<code>cv</code>
+<region>Atlantic Ocean</region>
+<uf>
+<name>Boa Vista</name>
+</uf>
+<uf>
+<name>Brava</name>
+</uf>
+<uf>
+<name>Cape Verde</name>
+</uf>
+<uf>
+<name>Fogo</name>
+</uf>
+<uf>
+<name>Maio</name>
+</uf>
+<uf>
+<name>Sal</name>
+</uf>
+<uf>
+<name>Santo Antao</name>
+</uf>
+<uf>
+<name>São Nicolau</name>
+</uf>
+<uf>
+<name>São Tiago</name>
+</uf>
+<uf>
+<name>São Vicente</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ca</uri>
+<name authorized="yes">Caribbean Netherlands</name>
+<code>ca</code>
+<region>West Indies</region>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+<uf>
+<name>BES Islands</name>
+</uf>
+<uf>
+<name>Bonaire</name>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+</uf>
+<uf>
+<name>Bonaire (Netherlands Antilles)</name>
+</uf>
+<uf>
+<name>Bonaire, Saint Eustatius, and Saba</name>
+</uf>
+<uf>
+<name>Dutch Caribbean</name>
+</uf>
+<uf>
+<name>Netherlands Antilles</name>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+</uf>
+<uf>
+<name>Saba</name>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+</uf>
+<uf>
+<name>Saba (Netherlands Antilles)</name>
+</uf>
+<uf>
+<name>Saint Eustatius</name>
+</uf>
+<uf>
+<name>Sint Eustatius</name>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+</uf>
+<uf>
+<name>Sint Eustatius (Netherlands Antilles)</name>
+</uf>
+<uf>
+<name>Statia (Netherlands Antilles)</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cj</uri>
+<name authorized="yes">Cayman Islands</name>
+<code>cj</code>
+<region>West Indies</region>
+<uf>
+<name>Cayman Brac Island</name>
+</uf>
+<uf>
+<name>Grand Cayman Island</name>
+</uf>
+<uf>
+<name>Little Cayman Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cx</uri>
+<name authorized="yes">Central African Republic</name>
+<code>cx</code>
+<region>Africa</region>
+<uf>
+<name>Central African Empire</name>
+</uf>
+<uf>
+<name>Ubangi-Shari</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cd</uri>
+<name authorized="yes">Chad</name>
+<code>cd</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cl</uri>
+<name authorized="yes">Chile</name>
+<code>cl</code>
+<region>South America</region>
+<uf>
+<name>Easter Island</name>
+</uf>
+<uf>
+<name>Isla de Pasqua</name>
+</uf>
+<uf>
+<name>Isla Sala y Gómez</name>
+</uf>
+<uf>
+<name>Islas Juan Fernández</name>
+</uf>
+<uf>
+<name>Juan Fernández, Islas</name>
+</uf>
+<uf>
+<name>Pasqua, Isla de</name>
+</uf>
+<uf>
+<name>Sala y Gómez, Isla</name>
+</uf>
+<uf>
+<name>San Félix</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cc</uri>
+<name authorized="yes">China</name>
+<code>cc</code>
+<region>Asia</region>
+<uf>
+<name>Hainan Island</name>
+</uf>
+<uf>
+<name>Hong Kong</name>
+<note>
+<name>Hong Kong</name>
+<code status="obsolete">hk</code>
+<date type="before">199710</date>
+</note>
+</uf>
+<uf>
+<name>Inner Mongolia</name>
+</uf>
+<uf>
+<name>Kowloon</name>
+</uf>
+<uf>
+<name>Macao</name>
+</uf>
+<uf>
+<name>Macau</name>
+<note>
+<name>Macao</name>
+<code status="obsolete">mh</code>
+<date type="before">200005</date>
+</note>
+</uf>
+<uf>
+<name>Manchuria</name>
+</uf>
+<uf>
+<name>Sinkiang</name>
+</uf>
+<uf>
+<name>New Territories</name>
+</uf>
+<uf>
+<name>Taipa</name>
+<note>
+<name>Macao</name>
+<code status="obsolete">mh</code>
+<date type="before">200005</date>
+</note>
+</uf>
+<uf>
+<name>Tibet</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ch</uri>
+<name authorized="yes">China (Republic : 1949- )</name>
+<code>ch</code>
+<region>Asia</region>
+<uf>
+<name>Formosa Island</name>
+</uf>
+<uf>
+<name>Nationalist China</name>
+</uf>
+<uf>
+<name>P'eng-hu Island</name>
+</uf>
+<uf>
+<name>Pescadores Islands</name>
+</uf>
+<uf>
+<name>Taiwan Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xa</uri>
+<name authorized="yes">Christmas Island (Indian Ocean)</name>
+<code>xa</code>
+<region>Indian Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xb</uri>
+<name authorized="yes">Cocos (Keeling) Islands</name>
+<code>xb</code>
+<region>Indian Ocean</region>
+<uf>
+<name>Keeling Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ck</uri>
+<name authorized="yes">Colombia</name>
+<code>ck</code>
+<region>South America</region>
+<uf>
+<name>Isla de Malpelo</name>
+</uf>
+<uf>
+<name>Malpelo, Isla de</name>
+</uf>
+<uf>
+<name>San Andrés y Providencia</name>
+</uf>
+<uf>
+<name>Serrana Bank</name>
+<note>
+<name>United States Misc. Caribbean Islands</name>
+<code status="obsolete">uc</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Serranilla Bank</name>
+<note>
+<name>United States Misc. Caribbean Islands</name>
+<code status="obsolete">uc</code>
+<date type="before">197801</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cou</uri>
+<name authorized="yes">Colorado</name>
+<code>cou</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cq</uri>
+<name authorized="yes">Comoros</name>
+<code>cq</code>
+<region>Indian Ocean</region>
+<uf>
+<name>Anjouan Island</name>
+</uf>
+<uf>
+<name>Comores</name>
+</uf>
+<uf>
+<name>Grande Comore Island</name>
+</uf>
+<uf>
+<name>Moheli Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cf</uri>
+<name authorized="yes">Congo (Brazzaville)</name>
+<code>cf</code>
+<region>Africa</region>
+<uf>
+<name>Middle Congo</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cg</uri>
+<name authorized="yes">Congo (Democratic Republic)</name>
+<code>cg</code>
+<region>Africa</region>
+<uf>
+<name>Belgian Congo</name>
+</uf>
+<uf>
+<name>Congo (Kinshasa)</name>
+</uf>
+<uf>
+<name>Democratic Republic of the Congo</name>
+</uf>
+<uf>
+<name>Zaire</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ctu</uri>
+<name authorized="yes">Connecticut </name>
+<code>ctu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cw</uri>
+<name authorized="yes">Cook Islands</name>
+<code>cw</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Danger Atoll</name>
+</uf>
+<uf>
+<name>Manihiki Atoll</name>
+</uf>
+<uf>
+<name>Penrhyn Atoll</name>
+</uf>
+<uf>
+<name>Rakahanga Atoll</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xga</uri>
+<name authorized="yes">Coral Sea Islands Territory</name>
+<code>xga</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cr</uri>
+<name authorized="yes">Costa Rica</name>
+<code>cr</code>
+<region>Central America</region>
+<uf>
+<name>Cocos Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/iv</uri>
+<name authorized="yes">Côte d'Ivoire</name>
+<code>iv</code>
+<region>Africa</region>
+<uf>
+<name>Ivory Coast</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ci</uri>
+<name authorized="yes">Croatia</name>
+<code>ci</code>
+<region>Europe</region>
+<note>
+<name>Yugoslavia</name>
+<code status="obsolete">yu</code>
+<date type="before">199210</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cu</uri>
+<name authorized="yes">Cuba</name>
+<code>cu</code>
+<region>West Indies</region>
+<uf>
+<name>Isle of Pines (Caribbean)</name>
+</uf>
+<uf>
+<name>Pines, Isle of (Caribbean)</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/co</uri>
+<name authorized="yes">Curaçao</name>
+<code>co</code>
+<region>West Indies</region>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+<uf>
+<name>Curaçao (Netherlands Antilles)</name>
+</uf>
+<uf>
+<name>Netherlands Antilles</name>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/cy</uri>
+<name authorized="yes">Cyprus</name>
+<code>cy</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xr</uri>
+<name authorized="yes">Czech Republic</name>
+<code>xr</code>
+<region>Europe</region>
+<note>
+<name>Czechoslovakia</name>
+<code status="obsolete">cs</code>
+<date type="before">199305</date>
+</note>
+<uf>
+<name>Czechoslovakia</name>
+<note>
+<name>Czechoslovakia</name>
+<code status="obsolete">cs</code>
+<date type="before">199305</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/deu</uri>
+<name authorized="yes">Delaware</name>
+<code>deu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/dk</uri>
+<name authorized="yes">Denmark</name>
+<code>dk</code>
+<region>Europe</region>
+<uf>
+<name>Bornholm Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/dcu</uri>
+<name authorized="yes">District of Columbia</name>
+<code>dcu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ft</uri>
+<name authorized="yes">Djibouti</name>
+<code>ft</code>
+<region>Africa</region>
+<uf>
+<name>Afars</name>
+</uf>
+<uf>
+<name>French Somaliland</name>
+</uf>
+<uf>
+<name>French Territory of the Afars and Issas</name>
+</uf>
+<uf>
+<name>Issas</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/dq</uri>
+<name authorized="yes">Dominica</name>
+<code>dq</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/dr</uri>
+<name authorized="yes">Dominican Republic</name>
+<code>dr</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ec</uri>
+<name authorized="yes">Ecuador</name>
+<code>ec</code>
+<region>South America</region>
+<uf>
+<name>Archipiélago de Colón</name>
+</uf>
+<uf>
+<name>Colón, Archipiélago de</name>
+</uf>
+<uf>
+<name>Galapagos Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ua</uri>
+<name authorized="yes">Egypt</name>
+<code>ua</code>
+<region>Africa</region>
+<uf>
+<name>Arab Republic of Egypt</name>
+</uf>
+<uf>
+<name>United Arab Republic</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/es</uri>
+<name authorized="yes">El Salvador</name>
+<code>es</code>
+<region>Central America</region>
+<uf>
+<name>Salvador</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/enk</uri>
+<name authorized="yes">England</name>
+<code>enk</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/eg</uri>
+<name authorized="yes">Equatorial Guinea</name>
+<code>eg</code>
+<region>Africa</region>
+<uf>
+<name>Annobón</name>
+</uf>
+<uf>
+<name>Bioko</name>
+</uf>
+<uf>
+<name>Corisco Island</name>
+</uf>
+<uf>
+<name>Elobey, Great</name>
+</uf>
+<uf>
+<name>Elobey, Small</name>
+</uf>
+<uf>
+<name>Fernando Po Island</name>
+</uf>
+<uf>
+<name>Macias Nguema Biyogo</name>
+</uf>
+<uf>
+<name>Pagalu</name>
+</uf>
+<uf>
+<name>Rio Muni</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ea</uri>
+<name authorized="yes">Eritrea</name>
+<code>ea</code>
+<region>Africa</region>
+<note>
+<name>Ethiopia</name>
+<code status="obsolete">et</code>
+<date type="before">199311</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/er</uri>
+<name authorized="yes">Estonia</name>
+<code>er</code>
+<region>Europe</region>
+<note>
+<name>Estonia</name>
+<code status="obsolete">err</code>
+<date type="before">199210</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/et</uri>
+<name authorized="yes">Ethiopia</name>
+<code>et</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fk</uri>
+<name authorized="yes">Falkland Islands</name>
+<code>fk</code>
+<region>Atlantic Ocean</region>
+<uf>
+<name>East Falkland Island</name>
+</uf>
+<uf>
+<name>Islas Malvinas</name>
+</uf>
+<uf>
+<name>Malvinas, Islas</name>
+</uf>
+<uf>
+<name>West Falkland Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fa</uri>
+<name authorized="yes">Faroe Islands</name>
+<code>fa</code>
+<region>Atlantic Ocean</region>
+<uf>
+<name>Færoe Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fj</uri>
+<name authorized="yes">Fiji</name>
+<code>fj</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Rotuma Island</name>
+</uf>
+<uf>
+<name>Vanua Levu Island</name>
+</uf>
+<uf>
+<name>Viti Levu Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fi</uri>
+<name authorized="yes">Finland</name>
+<code>fi</code>
+<region>Europe</region>
+<uf>
+<name>Ahvenanmaa</name>
+</uf>
+<uf>
+<name>Åland Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/flu</uri>
+<name authorized="yes">Florida</name>
+<code>flu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fr</uri>
+<name authorized="yes">France</name>
+<code>fr</code>
+<region>Europe</region>
+<uf>
+<name>Corsica</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fg</uri>
+<name authorized="yes">French Guiana</name>
+<code>fg</code>
+<region>South America</region>
+<uf>
+<name>Guiana, French</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fp</uri>
+<name authorized="yes">French Polynesia</name>
+<code>fp</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Austral Islands</name>
+</uf>
+<uf>
+<name>Clipperton Island</name>
+</uf>
+<uf>
+<name>Gambier Islands</name>
+</uf>
+<uf>
+<name>Iles Australes</name>
+</uf>
+<uf>
+<name>Iles du Vent</name>
+</uf>
+<uf>
+<name>Iles Sous le Vent</name>
+</uf>
+<uf>
+<name>Marquesas Islands</name>
+</uf>
+<uf>
+<name>Polynesia, French</name>
+</uf>
+<uf>
+<name>Society Islands</name>
+</uf>
+<uf>
+<name>Sous le Vent, Iles</name>
+</uf>
+<uf>
+<name>Tahiti</name>
+</uf>
+<uf>
+<name>Tuamotu Archipelago</name>
+</uf>
+<uf>
+<name>Vent, Iles du</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/go</uri>
+<name authorized="yes">Gabon</name>
+<code>go</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gm</uri>
+<name authorized="yes">Gambia</name>
+<code>gm</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gz</uri>
+<name authorized="yes">Gaza Strip</name>
+<code>gz</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gau</uri>
+<name authorized="yes">Georgia</name>
+<code>gau</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gs</uri>
+<name authorized="yes">Georgia (Republic)</name>
+<code>gs</code>
+<region>Asia</region>
+<note>
+<name>Georgian S.S.R.</name>
+<code status="obsolete">gsr</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Georgian S.S.R.</name>
+<note>
+<name>Georgian S.S.R.</name>
+<code status="obsolete">gsr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gw</uri>
+<name authorized="yes">Germany</name>
+<code>gw</code>
+<region>Europe</region>
+<uf>
+<name>Berlin, East</name>
+<note>
+<name>Germany (East)</name>
+<code status="obsolete">ge</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Berlin, West</name>
+<note>
+<name>West Berlin</name>
+<code status="obsolete">wb</code>
+<date type="before">199001</date>
+</note>
+</uf>
+<uf>
+<name>East Berlin</name>
+<note>
+<name>Germany (East)</name>
+<code status="obsolete">ge</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Germany (East)</name>
+<note>
+<name>Germany (East)</name>
+<code status="obsolete">ge</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Germany (West)</name>
+</uf>
+<uf>
+<name>Germany, Democratic Republic of</name>
+<note>
+<name>Germany (East)</name>
+<code status="obsolete">ge</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Germany, Federal Republic of</name>
+</uf>
+<uf>
+<name>West Berlin</name>
+<note>
+<name>West Berlin</name>
+<code status="obsolete">wb</code>
+<date type="before">199001</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gh</uri>
+<name authorized="yes">Ghana</name>
+<code>gh</code>
+<region>Africa</region>
+<uf>
+<name>Ashanti</name>
+</uf>
+<uf>
+<name>Gold Coast</name>
+</uf>
+<uf>
+<name>Northern Territories</name>
+</uf>
+<uf>
+<name>Togoland</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gi</uri>
+<name authorized="yes">Gibraltar</name>
+<code>gi</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gr</uri>
+<name authorized="yes">Greece</name>
+<code>gr</code>
+<region>Europe</region>
+<uf>
+<name>Aegean Islands</name>
+</uf>
+<uf>
+<name>Crete</name>
+</uf>
+<uf>
+<name>Dodecanese</name>
+</uf>
+<uf>
+<name>Ionian Islands</name>
+</uf>
+<uf>
+<name>Mount Athos</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gl</uri>
+<name authorized="yes">Greenland</name>
+<code>gl</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gd</uri>
+<name authorized="yes">Grenada</name>
+<code>gd</code>
+<region>West Indies</region>
+<uf>
+<name>Grenadine Islands, Southern</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gp</uri>
+<name authorized="yes">Guadeloupe</name>
+<code>gp</code>
+<region>West Indies</region>
+<uf>
+<name>Basse-Terre</name>
+</uf>
+<uf>
+<name>Grande-Terre</name>
+</uf>
+<uf>
+<name>Iles de la Petite Terre</name>
+</uf>
+<uf>
+<name>Iles des Saintes</name>
+</uf>
+<uf>
+<name>La Désirade</name>
+</uf>
+<uf>
+<name>Marie-Galante</name>
+</uf>
+<uf>
+<name>Petite Terre, Iles de</name>
+</uf>
+<uf>
+<name>Saintes, Iles des</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gu</uri>
+<name authorized="yes">Guam</name>
+<code>gu</code>
+<region>Pacific Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gt</uri>
+<name authorized="yes">Guatemala</name>
+<code>gt</code>
+<region>Central America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gg</uri>
+<name authorized="yes">Guernsey</name>
+<code>gg</code>
+<region>Europe</region>
+<note>
+<name>United Kingdom Misc. Islands</name>
+<code status="obsolete">uik</code>
+<date type="before">201804</date>
+</note>
+<uf>
+<name>Alderney</name>
+</uf>
+<uf>
+<name>Brechou</name>
+</uf>
+<uf>
+<name>Brecqhou</name>
+</uf>
+<uf>
+<name>Channel Islands</name>
+</uf>
+<uf>
+<name>Guernsey Island</name>
+</uf>
+<uf>
+<name>Herm</name>
+</uf>
+<uf>
+<name>Herm Island</name>
+</uf>
+<uf>
+<name>Jethou</name>
+</uf>
+<uf>
+<name>Lihou</name>
+</uf>
+<uf>
+<name>Sark</name>
+</uf>
+<uf>
+<name>Sark Island</name>
+</uf>
+<uf>
+<name>United Kingdom Misc. Islands</name>
+<note>
+<name>United Kingdom Misc. Islands</name>
+<code status="obsolete">uik</code>
+<date type="before">201804</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gv</uri>
+<name authorized="yes">Guinea</name>
+<code>gv</code>
+<region>Africa</region>
+<uf>
+<name>French Guinea</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pg</uri>
+<name authorized="yes">Guinea-Bissau</name>
+<code>pg</code>
+<region>Africa</region>
+<uf>
+<name>Arquipélago dos Bijagós</name>
+</uf>
+<uf>
+<name>Bijagós, Arquipélago dos</name>
+</uf>
+<uf>
+<name>Bissagos Islands</name>
+</uf>
+<uf>
+<name>Guinea, Portuguese</name>
+</uf>
+<uf>
+<name>Portuguese Guinea</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gy</uri>
+<name authorized="yes">Guyana</name>
+<code>gy</code>
+<region>South America</region>
+<uf>
+<name>British Guiana</name>
+</uf>
+<uf>
+<name>Guiana, British</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ht</uri>
+<name authorized="yes">Haiti</name>
+<code>ht</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/hiu</uri>
+<name authorized="yes">Hawaii</name>
+<code>hiu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/hm</uri>
+<name authorized="yes">Heard and McDonald Islands</name>
+<code>hm</code>
+<region>Indian Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ho</uri>
+<name authorized="yes">Honduras</name>
+<code>ho</code>
+<region>Central America</region>
+<uf>
+<name>Swan Islands</name>
+<note>
+<name>Swan Islands</name>
+<code status="obsolete">sv</code>
+<date type="before">197801</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/hu</uri>
+<name authorized="yes">Hungary</name>
+<code>hu</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ic</uri>
+<name authorized="yes">Iceland</name>
+<code>ic</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/idu</uri>
+<name authorized="yes">Idaho</name>
+<code>idu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ilu</uri>
+<name authorized="yes">Illinois</name>
+<code>ilu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ii</uri>
+<name authorized="yes">India</name>
+<code>ii</code>
+<region>Asia</region>
+<uf>
+<name>Amindivi Islands</name>
+</uf>
+<uf>
+<name>Andaman Islands</name>
+</uf>
+<uf>
+<name>Daman</name>
+</uf>
+<uf>
+<name>Diu</name>
+</uf>
+<uf>
+<name>Goa</name>
+</uf>
+<uf>
+<name>Laccadive Island</name>
+</uf>
+<uf>
+<name>Minicoy Island</name>
+</uf>
+<uf>
+<name>Nicobar Islands</name>
+</uf>
+<uf>
+<name>Sikkim</name>
+<note>
+<name>Sikkim</name>
+<code status="obsolete">sk</code>
+<date type="before">197801</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/inu</uri>
+<name authorized="yes">Indiana</name>
+<code>inu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/io</uri>
+<name authorized="yes">Indonesia</name>
+<name>Indonesia</name>
+<code>io</code>
+<region>Asia</region>
+<uf>
+<name>Irian Barat</name>
+</uf>
+<uf>
+<name>Netherlands New Guinea</name>
+</uf>
+<uf>
+<name>West New Guinea</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/iau</uri>
+<name authorized="yes">Iowa</name>
+<code>iau</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ir</uri>
+<name authorized="yes">Iran</name>
+<code>ir</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/iq</uri>
+<name authorized="yes">Iraq</name>
+<code>iq</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/iy</uri>
+<name authorized="yes">Iraq-Saudi Arabia Neutral Zone</name>
+<code>iy</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ie</uri>
+<name authorized="yes">Ireland</name>
+<code>ie</code>
+<region>Europe</region>
+<uf>
+<name>Eire</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/im</uri>
+<name authorized="yes">Isle of Man</name>
+<code>im</code>
+<region>Europe</region>
+<note>
+<name>United Kingdom Misc. Islands</name>
+<code status="obsolete">uik</code>
+<date type="before">201804</date>
+</note>
+<uf>
+<name>Calf of Man</name>
+</uf>
+<uf>
+<name>United Kingdom Misc. Islands</name>
+<note>
+<name>United Kingdom Misc. Islands</name>
+<code status="obsolete">uik</code>
+<date type="before">201804</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/is</uri>
+<name authorized="yes">Israel</name>
+<code>is</code>
+<region>Asia</region>
+<uf>
+<name>Israel-Jordan Demilitarized Zones</name>
+<note>
+<name>Israel-Jordan Demilitarized Zones</name>
+<code status="obsolete">iw</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Israel-Syria Demilitarized Zones</name>
+<note>
+<name>Israel-Syria Demilitarized Zones</name>
+<code status="obsolete">iu</code>
+<date type="before">197801</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/it</uri>
+<name authorized="yes">Italy</name>
+<code>it</code>
+<region>Europe</region>
+<uf>
+<name>Pantelleria</name>
+</uf>
+<uf>
+<name>Sardinia</name>
+</uf>
+<uf>
+<name>Sicily</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/jm</uri>
+<name authorized="yes">Jamaica</name>
+<code>jm</code>
+<region>West Indies</region>
+<uf>
+<name>Morant Cays</name>
+</uf>
+<uf>
+<name>Pedro Cays</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ja</uri>
+<name authorized="yes">Japan</name>
+<code>ja</code>
+<region>Asia</region>
+<uf>
+<name>Bonin Islands</name>
+</uf>
+<uf>
+<name>Daitojima</name>
+<note>
+<name>Ryukyu Islands, Southern</name>
+<code status="obsolete">ry</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Marcus Island</name>
+</uf>
+<uf>
+<name>Namposhoto (Northern)</name>
+</uf>
+<uf>
+<name>Namposhoto (Southern)</name>
+</uf>
+<uf>
+<name>Nishinoshima Island</name>
+</uf>
+<uf>
+<name>Okinawa</name>
+<note>
+<name>Ryukyu Islands, Southern</name>
+<code status="obsolete">ry</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Parece Vela Island</name>
+</uf>
+<uf>
+<name>Ryukyu Islands, Northern</name>
+</uf>
+<uf>
+<name>Ryukyu Islands, Southern</name>
+<note>
+<name>Ryukyu Islands, Southern</name>
+<code status="obsolete">ry</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Torishima</name>
+<note>
+<name>Ryukyu Islands, Southern</name>
+<code status="obsolete">ry</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Volcano Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/je</uri>
+<name authorized="yes">Jersey</name>
+<code>je</code>
+<region>Europe</region>
+<note>
+<name>United Kingdom Misc. Islands</name>
+<code status="obsolete">uik</code>
+<date type="before">201804</date>
+</note>
+<uf>
+<name>Channel Islands</name>
+</uf>
+<uf>
+<name>Jersey (Island)</name>
+</uf>
+<uf>
+<name>United Kingdom Misc. Islands</name>
+<note>
+<name>United Kingdom Misc. Islands</name>
+<code status="obsolete">uik</code>
+<date type="before">201804</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ji</uri>
+<name authorized="yes">Johnston Atoll</name>
+<code>ji</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Sand Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/jo</uri>
+<name authorized="yes">Jordan</name>
+<code>jo</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ksu</uri>
+<name authorized="yes">Kansas</name>
+<code>ksu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/kz</uri>
+<name authorized="yes">Kazakhstan</name>
+<code>kz</code>
+<region>Asia</region>
+<note>
+<name>Kazakh S.S.R.</name>
+<code status="obsolete">kzr</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Kazakh S.S.R.</name>
+<note>
+<name>Kazakh S.S.R.</name>
+<code status="obsolete">kzr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/kyu</uri>
+<name authorized="yes">Kentucky</name>
+<code>kyu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ke</uri>
+<name authorized="yes">Kenya</name>
+<code>ke</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/gb</uri>
+<name authorized="yes">Kiribati</name>
+<code>gb</code>
+<region>Pacific Ocean</region>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+<note>
+<name>Central and Southern Line Islands</name>
+<code status="obsolete">ln</code>
+<date type="before">197810</date>
+</note>
+<uf>
+<name>Banaba</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Birnie Island</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Canton Island</name>
+<note>
+<name>Canton and Enderbury Islands</name>
+<code status="obsolete">cp</code>
+<date type="before">199301</date>
+</note>
+</uf>
+<uf>
+<name>Caroline Island</name>
+<note>
+<name>Central and Southern Line Islands</name>
+<code status="obsolete">ln</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Central and Southern Line Islands</name>
+<note>
+<name>Central and Southern Line Islands</name>
+<code status="obsolete">ln</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Christmas Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Enderbury Island</name>
+<note>
+<name>Canton and Enderbury Islands</name>
+<code status="obsolete">cp</code>
+<date type="after">199312</date>
+</note>
+</uf>
+<uf>
+<name>Fanning Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Flint Island</name>
+<note>
+<name>Central and Southern Line Islands</name>
+<code status="obsolete">ln</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Gardner Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Gilbert and Ellice Islands</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Gilbert Islands</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Hull Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Kiritimati</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Line Islands (Southern)</name>
+<note>
+<name>Central and Southern Line Islands</name>
+<code status="obsolete">ln</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Malden Island</name>
+<note>
+<name>Central and Southern Line Islands</name>
+<code status="obsolete">ln</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Manra Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>McKean Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Nikomaroro Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Ocean Island</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Orona Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Phoenix Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Phoenix Islands</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Rawaki</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Starbuck Island</name>
+<note>
+<name>Central and Southern Line Islands</name>
+<code status="obsolete">ln</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Sydney Atoll</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Tabuarean Island</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Vostok Island</name>
+<note>
+<name>Central and Southern Line Islands</name>
+<code status="obsolete">ln</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Washington Island</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/kn</uri>
+<name authorized="yes">Korea (North)</name>
+<code>kn</code>
+<region>Asia</region>
+<uf>
+<name>Democratic People's Republic of Korea</name>
+</uf>
+<uf>
+<name>North Korea</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ko</uri>
+<name authorized="yes">Korea (South)</name>
+<code>ko</code>
+<region>Asia</region>
+<uf>
+<name>Korea, Republic of</name>
+</uf>
+<uf>
+<name>South Korea</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/kv</uri>
+<name authorized="yes">Kosovo</name>
+<code>kv</code>
+<region>Europe</region>
+<note>
+<text>
+Coded [rb] for Serbia from February 2007-May 2008. From 1992-April 2007 it was coded [yu] for Serbia and Montenegro
+</text>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ku</uri>
+<name authorized="yes">Kuwait</name>
+<code>ku</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/kg</uri>
+<name authorized="yes">Kyrgyzstan</name>
+<code>kg</code>
+<region>Asia</region>
+<note>
+<name>Kirghiz S.S.R.</name>
+<code status="obsolete">kgr</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Kirghiz S.S.R.</name>
+<note>
+<name>Kirghiz S.S.R.</name>
+<code status="obsolete">kgr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Kirghizia</name>
+<note>
+<name>Kirghiz S.S.R.</name>
+<code status="obsolete">kgr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ls</uri>
+<name authorized="yes">Laos</name>
+<code>ls</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/lv</uri>
+<name authorized="yes">Latvia</name>
+<code>lv</code>
+<region>Europe</region>
+<note>
+<name>Latvia</name>
+<code status="obsolete">lvr</code>
+<date type="before">199206</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/le</uri>
+<name authorized="yes">Lebanon</name>
+<code>le</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/lo</uri>
+<name authorized="yes">Lesotho</name>
+<code>lo</code>
+<region>Africa</region>
+<uf>
+<name>Basutoland</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/lb</uri>
+<name authorized="yes">Liberia</name>
+<code>lb</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ly</uri>
+<name authorized="yes">Libya</name>
+<code>ly</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/lh</uri>
+<name authorized="yes">Liechtenstein</name>
+<code>lh</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/li</uri>
+<name authorized="yes">Lithuania</name>
+<code>li</code>
+<region>Europe</region>
+<note>
+<name>Lithuania</name>
+<code status="obsolete">lir</code>
+<date type="before">199206</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/lau</uri>
+<name authorized="yes">Louisiana</name>
+<code>lau</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/lu</uri>
+<name authorized="yes">Luxembourg</name>
+<code>lu</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xn</uri>
+<name authorized="yes">Macedonia</name>
+<code>xn</code>
+<region>Europe</region>
+<note>
+<name>Yugoslavia</name>
+<code status="obsolete">yu</code>
+<date type="before">199210</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mg</uri>
+<name authorized="yes">Madagascar</name>
+<code>mg</code>
+<region>Africa</region>
+<uf>
+<name>Malagasy Republic</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/meu</uri>
+<name authorized="yes">Maine</name>
+<code>meu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mw</uri>
+<name authorized="yes">Malawi</name>
+<code>mw</code>
+<region>Africa</region>
+<uf>
+<name>Nyasaland</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/my</uri>
+<name authorized="yes">Malaysia</name>
+<code>my</code>
+<region>Asia</region>
+<uf>
+<name>Borneo, North</name>
+</uf>
+<uf>
+<name>Malaya</name>
+</uf>
+<uf>
+<name>North Borneo</name>
+</uf>
+<uf>
+<name>Sabah</name>
+</uf>
+<uf>
+<name>Sarawak</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xc</uri>
+<name authorized="yes">Maldives</name>
+<code>xc</code>
+<region>Indian Ocean</region>
+<uf>
+<name>Maldive Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ml</uri>
+<name authorized="yes">Mali</name>
+<code>ml</code>
+<region>Africa</region>
+<uf>
+<name>French Sudan</name>
+</uf>
+<uf>
+<name>Soudan</name>
+</uf>
+<uf>
+<name>Sudan, French</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mm</uri>
+<name authorized="yes">Malta</name>
+<code>mm</code>
+<region>Europe</region>
+<uf>
+<name>Comino Island</name>
+</uf>
+<uf>
+<name>Gozo Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mbc</uri>
+<name authorized="yes">Manitoba</name>
+<code>mbc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xe</uri>
+<name authorized="yes">Marshall Islands</name>
+<code>xe</code>
+<region>Pacific Ocean</region>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+<uf>
+<name>Ailinglapalap Atoll</name>
+</uf>
+<uf>
+<name>Arno (Atoll)</name>
+</uf>
+<uf>
+<name>Bikini (Atoll)</name>
+</uf>
+<uf>
+<name>Ebon Atoll</name>
+</uf>
+<uf>
+<name>Eniwetok Atoll</name>
+</uf>
+<uf>
+<name>Jaluit Atoll</name>
+</uf>
+<uf>
+<name>Kili Island</name>
+</uf>
+<uf>
+<name>Kwajalein Atoll</name>
+</uf>
+<uf>
+<name>Majuro Atoll</name>
+</uf>
+<uf>
+<name>Maloelap Atoll</name>
+</uf>
+<uf>
+<name>Mili Atoll</name>
+</uf>
+<uf>
+<name>Namorik Atoll</name>
+</uf>
+<uf>
+<name>Pacific Islands (Trust Territory)</name>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Ralik Chain</name>
+</uf>
+<uf>
+<name>Ratak Chains</name>
+</uf>
+<uf>
+<name>Rongelap Atoll</name>
+</uf>
+<uf>
+<name>Taongi Atoll</name>
+</uf>
+<uf>
+<name>Trust Territory of the Pacific Islands</name>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Ujelang Atoll</name>
+</uf>
+<uf>
+<name>Utirik Atoll</name>
+</uf>
+<uf>
+<name>Wotje Atoll</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mq</uri>
+<name authorized="yes">Martinique</name>
+<code>mq</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mdu</uri>
+<name authorized="yes">Maryland</name>
+<code>mdu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mau</uri>
+<name authorized="yes">Massachusetts</name>
+<code>mau</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mu</uri>
+<name authorized="yes">Mauritania</name>
+<code>mu</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mf</uri>
+<name authorized="yes">Mauritius</name>
+<code>mf</code>
+<region>Indian Ocean</region>
+<uf>
+<name>Agalega Islands</name>
+</uf>
+<uf>
+<name>Cargados Carajos Shoals</name>
+</uf>
+<uf>
+<name>Rodrigues Island</name>
+</uf>
+<uf>
+<name>Saint Brandon</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ot</uri>
+<name authorized="yes">Mayotte</name>
+<code>ot</code>
+<region>Indian Ocean</region>
+<note>
+<name>Comoros</name>
+<code status="obsolete">cq</code>
+<date type="before">198707</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mx</uri>
+<name authorized="yes">Mexico</name>
+<code>mx</code>
+<region>North America</region>
+<uf>
+<name>Islas de Revillagigedo</name>
+</uf>
+<uf>
+<name>Revillagigedo, Islas de</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/miu</uri>
+<name authorized="yes">Michigan</name>
+<code>miu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fm</uri>
+<name authorized="yes">Micronesia (Federated States)</name>
+<code>fm</code>
+<region>Pacific Ocean</region>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+<uf>
+<name>Ascension Island (Micronesia)</name>
+</uf>
+<uf>
+<name>Eauripik Atoll</name>
+</uf>
+<uf>
+<name>Fais Island</name>
+</uf>
+<uf>
+<name>Faraulep Atoll</name>
+</uf>
+<uf>
+<name>Federated States of Micronesia</name>
+</uf>
+<uf>
+<name>Gaferut Island</name>
+</uf>
+<uf>
+<name>Hall Islands</name>
+</uf>
+<uf>
+<name>Ifalik Atoll</name>
+</uf>
+<uf>
+<name>Kapingamarangi Atoll</name>
+</uf>
+<uf>
+<name>Kosrae (Micronesia)</name>
+</uf>
+<uf>
+<name>Kusaie (Micronesia)</name>
+</uf>
+<uf>
+<name>Mortlock Islands</name>
+</uf>
+<uf>
+<name>Namonuito Atoll</name>
+</uf>
+<uf>
+<name>Ngatik Atoll</name>
+</uf>
+<uf>
+<name>Ngulu Atoll</name>
+</uf>
+<uf>
+<name>Nukuoru Atoll</name>
+</uf>
+<uf>
+<name>Oroluk Atoll</name>
+</uf>
+<uf>
+<name>Pacific Islands (Trust Territory)</name>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Pingelap Atoll</name>
+</uf>
+<uf>
+<name>Pohnpei</name>
+</uf>
+<uf>
+<name>Ponape (Micronesia)</name>
+</uf>
+<uf>
+<name>Pulap Atoll</name>
+</uf>
+<uf>
+<name>Pulusak Island</name>
+</uf>
+<uf>
+<name>Puluwat Atoll</name>
+</uf>
+<uf>
+<name>Satawal Island</name>
+</uf>
+<uf>
+<name>Senyavin Islands</name>
+</uf>
+<uf>
+<name>Truk (Micronesia)</name>
+</uf>
+<uf>
+<name>Trust Territory of the Pacific Islands</name>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Ulithi Islands</name>
+</uf>
+<uf>
+<name>West Fayu Atoll</name>
+</uf>
+<uf>
+<name>Woleai Atolls</name>
+</uf>
+<uf>
+<name>Yap (Micronesia)</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xf</uri>
+<name authorized="yes">Midway Islands</name>
+<code>xf</code>
+<region>Pacific Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mnu</uri>
+<name authorized="yes">Minnesota</name>
+<code>mnu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/msu</uri>
+<name authorized="yes">Mississippi</name>
+<code>msu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mou</uri>
+<name authorized="yes">Missouri</name>
+<code>mou</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mv</uri>
+<name authorized="yes">Moldova</name>
+<code>mv</code>
+<region>Europe</region>
+<note>
+<name>Moldavian S.S.R.</name>
+<code status="obsolete">mvr</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Moldavian S.S.R.</name>
+<note>
+<name>Moldavian S.S.R.</name>
+<code status="obsolete">mvr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mc</uri>
+<name authorized="yes">Monaco</name>
+<code>mc</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mp</uri>
+<name authorized="yes">Mongolia</name>
+<code>mp</code>
+<region>Asia</region>
+<uf>
+<name>Mongolian People's Republic</name>
+</uf>
+<uf>
+<name>Outer Mongolia</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mtu</uri>
+<name authorized="yes">Montana</name>
+<code>mtu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mo</uri>
+<name authorized="yes">Montenegro</name>
+<code>mo</code>
+<region>Europe</region>
+<note>
+<text>
+Coded [yu] for Serbia and Montenegro from 1992-April 2007
+</text>
+</note>
+<uf>
+<name>Yugoslavia</name>
+<note>
+<name>Yugoslavia</name>
+<code status="obsolete">yu</code>
+<date type="before">199201</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mj</uri>
+<name authorized="yes">Montserrat</name>
+<code>mj</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mr</uri>
+<name authorized="yes">Morocco</name>
+<code>mr</code>
+<region>Africa</region>
+<uf>
+<name>French Morocco</name>
+</uf>
+<uf>
+<name>Ifni</name>
+</uf>
+<uf>
+<name>Spanish Morocco</name>
+</uf>
+<uf>
+<name>Tangier Zone</name>
+</uf>
+<uf>
+<name>Zona Sur del Protectorado de Marruecos</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mz</uri>
+<name authorized="yes">Mozambique</name>
+<code>mz</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sx</uri>
+<name authorized="yes">Namibia</name>
+<code>sx</code>
+<region>Africa</region>
+<uf>
+<name>South-West Africa</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nu</uri>
+<name authorized="yes">Nauru</name>
+<code>nu</code>
+<region>Pacific Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nbu</uri>
+<name authorized="yes">Nebraska</name>
+<code>nbu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/np</uri>
+<name authorized="yes">Nepal</name>
+<code>np</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ne</uri>
+<name authorized="yes">Netherlands</name>
+<code>ne</code>
+<region>Europe</region>
+<uf>
+<name>Holland</name>
+</uf>
+</country>
+ <!--
+ Made Obsolete Dec. 2011
+      <country>
+         <uri>info:lc/vocabulary/countries/na</uri>
+         <name authorized="yes">Netherlands Antilles</name>
+         <code>na</code>
+         <region>West Indies</region>
+         <uf>
+            <name>Bonaire</name>
+         </uf>
+         <uf>
+            <name>Curaçao</name>
+         </uf>
+         <uf>
+            <name>Saba</name>
+         </uf>
+         <uf>
+            <name>Saint Martin, Southern</name>
+         </uf>
+         <uf>
+            <name>Sint Eustatius</name>
+         </uf>
+      </country> 
+-->
+<country>
+<uri>info:lc/vocabulary/countries/nvu</uri>
+<name authorized="yes">Nevada</name>
+<code>nvu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nkc</uri>
+<name authorized="yes">New Brunswick</name>
+<code>nkc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nl</uri>
+<name authorized="yes">New Caledonia</name>
+<code>nl</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Belep Islands</name>
+</uf>
+<uf>
+<name>Chesterfield, Iles</name>
+</uf>
+<uf>
+<name>Huon, Ile</name>
+</uf>
+<uf>
+<name>Ile des Pins</name>
+</uf>
+<uf>
+<name>Ile Huon</name>
+</uf>
+<uf>
+<name>Ile Uvea (New Caledonia)</name>
+</uf>
+<uf>
+<name>Ile Walpole</name>
+</uf>
+<uf>
+<name>Iles Belep</name>
+</uf>
+<uf>
+<name>Iles Chesterfield</name>
+</uf>
+<uf>
+<name>Isle of Pines (Pacific Ocean)</name>
+</uf>
+<uf>
+<name>Loyalty Islands</name>
+</uf>
+<uf>
+<name>Pines, Isle of (Pacific Ocean)</name>
+</uf>
+<uf>
+<name>Pins, Ile des</name>
+</uf>
+<uf>
+<name>Uvea (New Caledonia)</name>
+</uf>
+<uf>
+<name>Walpole, Ile</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nhu</uri>
+<name authorized="yes">New Hampshire</name>
+<code>nhu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nju</uri>
+<name authorized="yes">New Jersey</name>
+<code>nju</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nmu</uri>
+<name authorized="yes">New Mexico</name>
+<code>nmu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xna</uri>
+<name authorized="yes">New South Wales</name>
+<code>xna</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nyu</uri>
+<name authorized="yes">New York (State)</name>
+<code>nyu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nz</uri>
+<name authorized="yes">New Zealand</name>
+<code>nz</code>
+<region>Australasia</region>
+<uf>
+<name>Chatham Islands</name>
+</uf>
+<uf>
+<name>Kermadec Islands</name>
+</uf>
+<uf>
+<name>North Island</name>
+</uf>
+<uf>
+<name>South Island</name>
+</uf>
+<uf>
+<name>Stewart Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nfc</uri>
+<name authorized="yes">Newfoundland and Labrador</name>
+<code>nfc</code>
+<region>North America</region>
+<uf>
+<name>Labrador</name>
+</uf>
+<uf>
+<name>Newfoundland</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nq</uri>
+<name authorized="yes">Nicaragua</name>
+<code>nq</code>
+<region>Central America</region>
+<uf>
+<name>Corn Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ng</uri>
+<name authorized="yes">Niger</name>
+<code>ng</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nr</uri>
+<name authorized="yes">Nigeria</name>
+<code>nr</code>
+<region>Africa</region>
+<uf>
+<name>British Cameroons, Northern</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xh</uri>
+<name authorized="yes">Niue</name>
+<code>xh</code>
+<region>Pacific Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xx</uri>
+<name authorized="yes">No place, unknown, or undetermined</name>
+<code>xx</code>
+<region>Other</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nx</uri>
+<name authorized="yes">Norfolk Island </name>
+<code>nx</code>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ncu</uri>
+<name authorized="yes">North Carolina</name>
+<code>ncu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ndu</uri>
+<name authorized="yes">North Dakota</name>
+<code>ndu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nik</uri>
+<name authorized="yes">Northern Ireland</name>
+<code>nik</code>
+<region>Europe</region>
+<uf>
+<name>Ireland, Northern</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nw</uri>
+<name authorized="yes">Northern Mariana Islands</name>
+<code>nw</code>
+<region>Pacific Ocean</region>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198501</date>
+</note>
+<note>
+<name>Northern Mariana Islands</name>
+<code status="obsolete">nm</code>
+<date type="before">198707</date>
+</note>
+<uf>
+<name>Agrihan Island</name>
+</uf>
+<uf>
+<name>Aguijan Island</name>
+</uf>
+<uf>
+<name>Alamagan Island</name>
+</uf>
+<uf>
+<name>Anatahan Island</name>
+</uf>
+<uf>
+<name>Asuncion Island</name>
+</uf>
+<uf>
+<name>Farallon de Medinilla Island</name>
+</uf>
+<uf>
+<name>Farallon de Pajaros Island</name>
+</uf>
+<uf>
+<name>Guguan Island</name>
+</uf>
+<uf>
+<name>Mariana Islands</name>
+</uf>
+<uf>
+<name>Maug Islands</name>
+</uf>
+<uf>
+<name>Pacific Islands (Trust Territory)</name>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Pagan Island</name>
+</uf>
+<uf>
+<name>Rota Island</name>
+</uf>
+<uf>
+<name>Saipan Island</name>
+</uf>
+<uf>
+<name>Sarigan Island</name>
+</uf>
+<uf>
+<name>Tinian Island</name>
+</uf>
+<uf>
+<name>Trust Territory of the Pacific Islands</name>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xoa</uri>
+<name authorized="yes">Northern Territory</name>
+<code>xoa</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ntc</uri>
+<name authorized="yes">Northwest Territories</name>
+<code>ntc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/no</uri>
+<name authorized="yes">Norway</name>
+<code>no</code>
+<region>Europe</region>
+<uf>
+<name>Bear Island</name>
+</uf>
+<uf>
+<name>Jan Mayen</name>
+<note>
+<name>Jan Mayen</name>
+<code status="obsolete">jn</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Spitsbergen</name>
+</uf>
+<uf>
+<name>Svalbard (Norway)</name>
+<note>
+<name>Svalbard</name>
+<code status="obsolete">sb</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nsc</uri>
+<name authorized="yes">Nova Scotia</name>
+<code>nsc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nuc</uri>
+<name authorized="yes">Nunavut</name>
+<code>nuc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ohu</uri>
+<name authorized="yes">Ohio</name>
+<code>ohu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/oku</uri>
+<name authorized="yes">Oklahoma</name>
+<code>oku</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/mk</uri>
+<name authorized="yes">Oman</name>
+<code>mk</code>
+<region>Asia</region>
+<uf>
+<name>Kuria Muria Islands</name>
+</uf>
+<uf>
+<name>Muscat and Oman</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/onc</uri>
+<name authorized="yes">Ontario</name>
+<code>onc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/oru</uri>
+<name authorized="yes">Oregon</name>
+<code>oru</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pk</uri>
+<name authorized="yes">Pakistan</name>
+<code>pk</code>
+<region>Asia</region>
+<uf>
+<name>Gwadar</name>
+</uf>
+<uf>
+<name>West Pakistan</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pw</uri>
+<name authorized="yes">Palau</name>
+<code>pw</code>
+<region>Pacific Ocean</region>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+<uf>
+<name>Angaur Island</name>
+</uf>
+<uf>
+<name>Babelthuap Island</name>
+</uf>
+<uf>
+<name>Belau</name>
+</uf>
+<uf>
+<name>Helen Island</name>
+</uf>
+<uf>
+<name>Merir Island</name>
+</uf>
+<uf>
+<name>Pacific Islands (Trust Territory)</name>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Peleliu Island</name>
+</uf>
+<uf>
+<name>Pelew</name>
+</uf>
+<uf>
+<name>Pulo Anna Island</name>
+</uf>
+<uf>
+<name>Sonsoral Islands</name>
+</uf>
+<uf>
+<name>Tobi Island</name>
+</uf>
+<uf>
+<name>Trust Territory of the Pacific Islands</name>
+<note>
+<name>Trust Territory of the Pacific Islands</name>
+<code status="obsolete">tt</code>
+<date type="before">198803</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pn</uri>
+<name authorized="yes">Panama</name>
+<code>pn</code>
+<region>Central America</region>
+<uf>
+<name>Canal Zone</name>
+<note>
+<name>Canal Zone</name>
+<code status="obsolete">cz</code>
+<date type="before">198501</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pp</uri>
+<name authorized="yes">Papua New Guinea</name>
+<code>pp</code>
+<region>Asia</region>
+<uf>
+<name>Admiralty Islands</name>
+</uf>
+<uf>
+<name>Bismarck Archipelago</name>
+</uf>
+<uf>
+<name>D'Entrecasteaux Islands</name>
+</uf>
+<uf>
+<name>Louisiada Archipelago</name>
+</uf>
+<uf>
+<name>New Britain Island</name>
+</uf>
+<uf>
+<name>New Guinea</name>
+</uf>
+<uf>
+<name>New Ireland Island</name>
+</uf>
+<uf>
+<name>North East New Guinea</name>
+</uf>
+<uf>
+<name>Solomon Islands, Northern</name>
+</uf>
+<uf>
+<name>Trobriand Islands</name>
+</uf>
+<uf>
+<name>Woodlark Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pf</uri>
+<name authorized="yes">Paracel Islands]</name>
+<code>pf</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/py</uri>
+<name authorized="yes">Paraguay</name>
+<code>py</code>
+<region>South America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pau</uri>
+<name authorized="yes">Pennsylvania</name>
+<code>pau</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pe</uri>
+<name authorized="yes">Peru</name>
+<code>pe</code>
+<region>South America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ph</uri>
+<name authorized="yes">Philippines</name>
+<code>ph</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pc</uri>
+<name authorized="yes">Pitcairn Island</name>
+<code>pc</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Ducie Atoll</name>
+</uf>
+<uf>
+<name>Henderson Island</name>
+</uf>
+<uf>
+<name>Oeno Atoll</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pl</uri>
+<name authorized="yes">Poland</name>
+<code>pl</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/po</uri>
+<name authorized="yes">Portugal</name>
+<code>po</code>
+<region>Europe</region>
+<uf>
+<name>Azores</name>
+</uf>
+<uf>
+<name>Madeira Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pic</uri>
+<name authorized="yes">Prince Edward Island</name>
+<code>pic</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/pr</uri>
+<name authorized="yes">Puerto Rico</name>
+<code>pr</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/qa</uri>
+<name authorized="yes">Qatar</name>
+<code>qa</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/quc</uri>
+<name authorized="yes">Québec (Province)</name>
+<code>quc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/qea</uri>
+<name authorized="yes">Queensland</name>
+<code>qea</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/re</uri>
+<name authorized="yes">Réunion</name>
+<code>re</code>
+<region>Indian Ocean</region>
+<uf>
+<name>Bassas da India</name>
+</uf>
+<uf>
+<name>Europa, Ile</name>
+</uf>
+<uf>
+<name>Glorieuses, Iles</name>
+</uf>
+<uf>
+<name>Ile Europa</name>
+</uf>
+<uf>
+<name>Ile Juan de Nova</name>
+</uf>
+<uf>
+<name>Ile Tromelin</name>
+</uf>
+<uf>
+<name>Iles Glorieuses</name>
+</uf>
+<uf>
+<name>Juan de Nova, Ile</name>
+</uf>
+<uf>
+<name>Tromelin, Ile</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/riu</uri>
+<name authorized="yes">Rhode Island</name>
+<code>riu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/rm</uri>
+<name authorized="yes">Romania</name>
+<code>rm</code>
+<region>Europe</region>
+<uf>
+<name>Rumania</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ru</uri>
+<name authorized="yes">Russia (Federation)</name>
+<code>ru</code>
+<region>Europe</region>
+<note>
+<name>Russian S.F.S.R.</name>
+<code status="obsolete">rur</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Franz Josef Land</name>
+</uf>
+<uf>
+<name>Habomai Islands</name>
+</uf>
+<uf>
+<name>Kuril Islands (Southern)</name>
+</uf>
+<uf>
+<name>New Siberian Islands</name>
+</uf>
+<uf>
+<name>Novaya Zemlya</name>
+</uf>
+<uf>
+<name>Russian S.F.S.R.</name>
+<note>
+<name>Russian S.F.S.R.</name>
+<code status="obsolete">rur</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Sakhalin (Southern)</name>
+</uf>
+<uf>
+<name>Severnaya Zemlya</name>
+</uf>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Wrangel Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/rw</uri>
+<name authorized="yes">Rwanda</name>
+<code>rw</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sc</uri>
+<name authorized="yes">Saint-Barthélemy</name>
+<code>sc</code>
+<note>
+<text>Coded [gp] (Guadeloupe) before Dec. 2011</text>
+</note>
+<region>West Indies</region>
+<uf>
+<name>Ile Saint-Barthélemy</name>
+</uf>
+<uf>
+<name>Saint Bartholomew</name>
+</uf>
+<uf>
+<name>Saint Barts</name>
+</uf>
+<uf>
+<name>St. Barthélemy</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xj</uri>
+<name authorized="yes">Saint Helena</name>
+<code>xj</code>
+<region>Atlantic Ocean</region>
+<uf>
+<name>Ascension Island (Atlantic Ocean)</name>
+</uf>
+<uf>
+<name>Gough Island</name>
+</uf>
+<uf>
+<name>Inaccessible Island</name>
+</uf>
+<uf>
+<name>Nightingale Island</name>
+</uf>
+<uf>
+<name>Tristan da Cunha Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xd</uri>
+<name authorized="yes">Saint Kitts-Nevis</name>
+<code>xd</code>
+<region>West Indies</region>
+<note>
+<name>Saint Kitts-Nevis-Anguilla</name>
+<code status="obsolete">xi</code>
+<date type="before">198501</date>
+</note>
+<uf>
+<name>Saint Christopher</name>
+</uf>
+<uf>
+<name>Saint Kitts-Nevis-Anguilla</name>
+<note>
+<name>Saint Kitts-Nevis-Anguilla</name>
+<code status="obsolete">xi</code>
+<date type="before">19850101</date>
+</note>
+</uf>
+<uf>
+<name>St. Christopher</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xk</uri>
+<name authorized="yes">Saint Lucia</name>
+<code>xk</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/st</uri>
+<name authorized="yes">Saint-Martin</name>
+<code>st</code>
+<region>West Indies</region>
+<uf>
+<name>Collectivity of Saint Martin</name>
+</uf>
+<uf>
+<name>Saint-Martin (Collectivity)</name>
+</uf>
+<uf>
+<name>Saint-Martin (France: Collectivity)</name>
+</uf>
+<uf>
+<name>Saint Martin, Northern</name>
+<note>
+<text>Coded [gp] (Guadeloupe) before Dec. 2011</text>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xl</uri>
+<name authorized="yes">Saint Pierre and Miquelon</name>
+<code>xl</code>
+<region>North America</region>
+<uf>
+<name>Miquelon</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xm</uri>
+<name authorized="yes">Saint Vincent and the Grenadines</name>
+<code>xm</code>
+<region>West Indies</region>
+<uf>
+<name>Grenadine Islands, Northern</name>
+</uf>
+<uf>
+<name>Saint Vincent</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ws</uri>
+<name authorized="yes">Samoa</name>
+<code>ws</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Samoa i Sisifo</name>
+</uf>
+<uf>
+<name>Samoa, Western</name>
+</uf>
+<uf>
+<name>Savai'i</name>
+</uf>
+<uf>
+<name>Upolu</name>
+</uf>
+<uf>
+<name>Western Samoa</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sm</uri>
+<name authorized="yes">San Marino</name>
+<code>sm</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sf</uri>
+<name authorized="yes">Sao Tome and Principe</name>
+<code>sf</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/snc</uri>
+<name authorized="yes">Saskatchewan</name>
+<code>snc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/su</uri>
+<name authorized="yes">Saudi Arabia</name>
+<code>su</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/stk</uri>
+<name authorized="yes">Scotland</name>
+<code>stk</code>
+<region>Europe</region>
+<uf>
+<name>Orkney Islands</name>
+</uf>
+<uf>
+<name>Shetland Islands</name>
+</uf>
+<uf>
+<name>United Kingdom Misc. Islands</name>
+<note>
+<name>United Kingdom Misc. Islands</name>
+<code status="obsolete">uik</code>
+<date type="before">201804</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sg</uri>
+<name authorized="yes">Senegal</name>
+<code>sg</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/rb</uri>
+<name authorized="yes">Serbia</name>
+<code>rb</code>
+<region>Europe</region>
+<note>
+<text>
+Coded [yu] for Serbia and Montenegro from 1992-April 2007
+</text>
+</note>
+<uf>
+<name>Yugoslavia</name>
+<note>
+<name>Yugoslavia</name>
+<code status="obsolete">yu</code>
+<date type="before">199201</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/se</uri>
+<name authorized="yes">Seychelles</name>
+<code>se</code>
+<region>Indian Ocean</region>
+<uf>
+<name>Aldabra Islands</name>
+<note>
+<name>British Indian Ocean Territory</name>
+<code status="obsolete">bi</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Alphonse Island</name>
+</uf>
+<uf>
+<name>Amirante Isles</name>
+</uf>
+<uf>
+<name>Bijoutier Island</name>
+</uf>
+<uf>
+<name>Cosmoledo Islands</name>
+</uf>
+<uf>
+<name>Desroches, Ile</name>
+<note>
+<name>British Indian Ocean Territory</name>
+<code status="obsolete">bi</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Farquhar Atoll</name>
+<note>
+<name>British Indian Ocean Territory</name>
+<code status="obsolete">bi</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>François Island</name>
+</uf>
+<uf>
+<name>Ile Desroches</name>
+<note>
+<name>British Indian Ocean Territory</name>
+<code status="obsolete">bi</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Saint Francois Island</name>
+</uf>
+<uf>
+<name>Saint Pierre Islet</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sl</uri>
+<name authorized="yes">Sierra Leone</name>
+<code>sl</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/si</uri>
+<name authorized="yes">Singapore</name>
+<code>si</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sn</uri>
+<name authorized="yes">Sint Maarten</name>
+<code>sn</code>
+<region>West Indies</region>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+<uf>
+<name>Netherlands Antilles</name>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+</uf>
+<uf>
+<name>Saint Martin, Southern</name>
+<note>
+<name>Netherlands Antilles</name>
+<code status="obsolete">na</code>
+<date type="before">201112</date>
+</note>
+</uf>
+<uf>
+<name>Sint Maarten (Netherlands Antilles)</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xo</uri>
+<name authorized="yes">Slovakia</name>
+<code>xo</code>
+<region>Europe</region>
+<note>
+<name>Czechoslovakia</name>
+<code status="obsolete">cs</code>
+<date type="before">199306</date>
+</note>
+<uf>
+<name>Czechoslovakia</name>
+<note>
+<name>Czechoslovakia</name>
+<code status="obsolete">cs</code>
+<date type="before">199305</date>
+</note>
+</uf>
+<uf>
+<name>Slovak Socialist Republic</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xv</uri>
+<name authorized="yes">Slovenia</name>
+<code>xv</code>
+<region>Europe</region>
+<note>
+<name>Yugoslavia</name>
+<code status="obsolete">yu</code>
+<date type="before">199210</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/bp</uri>
+<name authorized="yes">Solomon Islands</name>
+<code>bp</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>British Solomon Islands</name>
+</uf>
+<uf>
+<name>Choiseul</name>
+</uf>
+<uf>
+<name>Guadalcanal</name>
+</uf>
+<uf>
+<name>Malaita</name>
+</uf>
+<uf>
+<name>San Cristóbal</name>
+</uf>
+<uf>
+<name>Santa Isabel</name>
+</uf>
+<uf>
+<name>Solomon Islands Protectorate</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/so</uri>
+<name authorized="yes">Somalia</name>
+<code>so</code>
+<region>Africa</region>
+<uf>
+<name>Somali Republic</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sa</uri>
+<name authorized="yes">South Africa</name>
+<code>sa</code>
+<region>Africa</region>
+<uf>
+<name>Bophuthatswana</name>
+</uf>
+<uf>
+<name>Ciskei</name>
+</uf>
+<uf>
+<name>Lebowa</name>
+</uf>
+<uf>
+<name>Machangana</name>
+</uf>
+<uf>
+<name>Marion Island</name>
+</uf>
+<uf>
+<name>Prince Edward Islands</name>
+</uf>
+<uf>
+<name>South Sotho</name>
+</uf>
+<uf>
+<name>Transkei</name>
+</uf>
+<uf>
+<name>Tswana</name>
+</uf>
+<uf>
+<name>Venda</name>
+</uf>
+<uf>
+<name>Walvis Bay Enclave</name>
+</uf>
+<uf>
+<name>Zulu</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xra</uri>
+<name authorized="yes">South Australia</name>
+<code>xra</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/scu</uri>
+<name authorized="yes">South Carolina</name>
+<code>scu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sdu</uri>
+<name authorized="yes">South Dakota</name>
+<code>sdu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xs</uri>
+<name authorized="yes">South Georgia and the South Sandwich Islands</name>
+<code>xs</code>
+<region>Atlantic Ocean</region>
+<note>
+<name>Falkland Islands</name>
+<code status="obsolete">fk</code>
+<date type="before">199101</date>
+</note>
+<uf>
+<name>South Georgia Island</name>
+<note>
+<name>Falkland Islands</name>
+<code status="obsolete">fk</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>South Sandwich Islands</name>
+<note>
+<name>Falkland Islands</name>
+<code status="obsolete">fk</code>
+<date type="before">199101</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sd</uri>
+<name authorized="yes">South Sudan</name>
+<code>sd</code>
+<note>
+<text>Coded [sj] (Sudan) before Aug. 2011</text>
+</note>
+<region>Africa</region>
+<uf>
+<name>Sudan, South</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sp</uri>
+<name authorized="yes">Spain</name>
+<code>sp</code>
+<region>Europe</region>
+<uf>
+<name>Balearic Islands</name>
+</uf>
+<uf>
+<name>Canary Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sh</uri>
+<name authorized="yes">Spanish North Africa</name>
+<code>sh</code>
+<region>Africa</region>
+<uf>
+<name>Ceuta</name>
+</uf>
+<uf>
+<name>Chafarinas, Islas</name>
+</uf>
+<uf>
+<name>Islas Chafarinas</name>
+</uf>
+<uf>
+<name>Melilla</name>
+</uf>
+<uf>
+<name>Peñón de Alhucemas</name>
+</uf>
+<uf>
+<name>Peñón de Vélez de la Gomera</name>
+</uf>
+<uf>
+<name>Plazas de Soberania</name>
+</uf>
+<uf>
+<name>Spanish Territories in Northern Morocco</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xp</uri>
+<name authorized="yes">Spratly Island</name>
+<code>xp</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ce</uri>
+<name authorized="yes">Sri Lanka</name>
+<code>ce</code>
+<region>Asia</region>
+<uf>
+<name>Ceylon</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sj</uri>
+<name authorized="yes">Sudan</name>
+<code>sj</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sr</uri>
+<name authorized="yes">Surinam</name>
+<code>sr</code>
+<region>South America</region>
+<uf>
+<name>Dutch Guiana</name>
+</uf>
+<uf>
+<name>Guiana, Dutch</name>
+</uf>
+<uf>
+<name>Netherlands Guiana</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sq</uri>
+<name authorized="yes">Swaziland</name>
+<code>sq</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sw</uri>
+<name authorized="yes">Sweden</name>
+<code>sw</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sz</uri>
+<name authorized="yes">Switzerland</name>
+<code>sz</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/sy</uri>
+<name authorized="yes">Syria</name>
+<code>sy</code>
+<region>Asia</region>
+<uf>
+<name>Syrian Arab Republic</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ta</uri>
+<name authorized="yes">Tajikistan</name>
+<code>ta</code>
+<region>Asia</region>
+<note>
+<name>Tajik S.S.R.</name>
+<code status="obsolete">tar</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Tadzhik S.S.R.</name>
+<note>
+<name>Tajik S.S.R.</name>
+<code status="obsolete">tar</code>
+<date type="before">199206</date>
+</note>
+</uf>
+<uf>
+<name>Tajik S.S.R.</name>
+<note>
+<name>Tajik S.S.R.</name>
+<code status="obsolete">tar</code>
+<date type="before">199206</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tz</uri>
+<name authorized="yes">Tanzania</name>
+<code>tz</code>
+<region>Africa</region>
+<uf>
+<name>Pemba</name>
+</uf>
+<uf>
+<name>Tanganyika</name>
+</uf>
+<uf>
+<name>Zanzibar</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tma</uri>
+<name authorized="yes">Tasmania</name>
+<code>tma</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tnu</uri>
+<name authorized="yes">Tennessee</name>
+<code>tnu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/fs</uri>
+<name authorized="yes">Terres australes et antarctiques françaises</name>
+<code>fs</code>
+<region>Indian Ocean</region>
+<uf>
+<name>Amsterdam Island</name>
+</uf>
+<uf>
+<name>Crozet Island</name>
+</uf>
+<uf>
+<name>French Southern and Antarctic Lands</name>
+</uf>
+<uf>
+<name>Kerguelen Island</name>
+</uf>
+<uf>
+<name>Saint Paul Island</name>
+</uf>
+<uf>
+<name>T.A.A.F.</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/txu</uri>
+<name authorized="yes">Texas</name>
+<code>txu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/th</uri>
+<name authorized="yes">Thailand</name>
+<code>th</code>
+<region>Asia</region>
+<uf>
+<name>Siam</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/em</uri>
+<name authorized="yes">Timor-Leste</name>
+<code>em</code>
+<region>Asia</region>
+<uf>
+<name>Atauro, Ilha de</name>
+<note>
+<name>Portuguese Timor</name>
+<code status="obsolete">pt</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>East Timor</name>
+</uf>
+<uf>
+<name>Ilha de Atauro</name>
+<note>
+<name>Portuguese Timor</name>
+<code status="obsolete">pt</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Ilheu de Jaco</name>
+<note>
+<name>Portuguese Timor</name>
+<code status="obsolete">pt</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Jaco, Ilheu de</name>
+<note>
+<name>Portuguese Timor</name>
+<code status="obsolete">pt</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Oe-Cussi</name>
+<note>
+<name>Portuguese Timor</name>
+<code status="obsolete">pt</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Portuguese Timor</name>
+<note>
+<name>Portuguese Timor</name>
+<code status="obsolete">pt</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Timor, East</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tg</uri>
+<name authorized="yes">Togo</name>
+<code>tg</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tl</uri>
+<name authorized="yes">Tokelau</name>
+<code>tl</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Atafu Atoll</name>
+</uf>
+<uf>
+<name>Fakaofu Atoll</name>
+</uf>
+<uf>
+<name>Nukunono Atoll</name>
+</uf>
+<uf>
+<name>Union Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/to</uri>
+<name authorized="yes">Tonga</name>
+<code>to</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Friendly Islands</name>
+</uf>
+<uf>
+<name>Haapai</name>
+</uf>
+<uf>
+<name>Lulunga</name>
+</uf>
+<uf>
+<name>Nomuka</name>
+</uf>
+<uf>
+<name>Otu Tolu</name>
+</uf>
+<uf>
+<name>Tongatapu</name>
+</uf>
+<uf>
+<name>Vavau</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tr</uri>
+<name authorized="yes">Trinidad and Tobago</name>
+<code>tr</code>
+<region>West Indies</region>
+<uf>
+<name>Tobago</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ti</uri>
+<name authorized="yes">Tunisia</name>
+<code>ti</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tu</uri>
+<name authorized="yes">Turkey</name>
+<code>tu</code>
+<region>Asia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tk</uri>
+<name authorized="yes">Turkmenistan</name>
+<code>tk</code>
+<region>Asia</region>
+<note>
+<name>Turkmen S.S.R.</name>
+<code status="obsolete">tkr</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Turkmen S.S.R.</name>
+<note>
+<name>Turkmen S.S.R.</name>
+<code status="obsolete">tkr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tc</uri>
+<name authorized="yes">Turks and Caicos Islands</name>
+<code>tc</code>
+<region>West Indies</region>
+<uf>
+<name>Caicos Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/tv</uri>
+<name authorized="yes">Tuvalu</name>
+<code>tv</code>
+<region>Pacific Ocean</region>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+<uf>
+<name>Ellice Islands</name>
+</uf>
+<uf>
+<name>Funafuti Atoll</name>
+</uf>
+<uf>
+<name>Gilbert and Ellice Islands</name>
+<note>
+<name>Gilbert and Ellice Islands</name>
+<code status="obsolete">gn</code>
+<date type="before">197810</date>
+</note>
+</uf>
+<uf>
+<name>Niulakita Island</name>
+</uf>
+<uf>
+<name>Nukufetau Atoll</name>
+</uf>
+<uf>
+<name>Nukulaelae Atoll</name>
+</uf>
+<uf>
+<name>Nukulailai Atoll</name>
+</uf>
+<uf>
+<name>Nurakita Island</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ug</uri>
+<name authorized="yes">Uganda</name>
+<code>ug</code>
+<region>Africa</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/un</uri>
+<name authorized="yes">Ukraine</name>
+<code>un</code>
+<region>Europe</region>
+<note>
+<name>Ukraine</name>
+<code status="obsolete">unr</code>
+<date type="before">199206</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ts</uri>
+<name authorized="yes">United Arab Emirates</name>
+<code>ts</code>
+<region>Asia</region>
+<uf>
+<name>Abu Dhabi</name>
+</uf>
+<uf>
+<name>Abu Zaby</name>
+</uf>
+<uf>
+<name>`Ajman</name>
+</uf>
+<uf>
+<name>Dubai</name>
+</uf>
+<uf>
+<name>Dubayy</name>
+</uf>
+<uf>
+<name>Fujairah</name>
+</uf>
+<uf>
+<name>Fujayrah</name>
+</uf>
+<uf>
+<name>Kalba</name>
+</uf>
+<uf>
+<name>Oman, Trucial</name>
+</uf>
+<uf>
+<name>Ras al Khaimah</name>
+</uf>
+<uf>
+<name>Ra's al-Khaymah</name>
+</uf>
+<uf>
+<name>Shariqah</name>
+</uf>
+<uf>
+<name>Sharjah</name>
+</uf>
+<uf>
+<name>Trucial Coast</name>
+</uf>
+<uf>
+<name>Trucial Oman</name>
+</uf>
+<uf>
+<name>Trucial Sheikdoms</name>
+</uf>
+<uf>
+<name>Trucial States</name>
+</uf>
+<uf>
+<name>Umm al Qaiwain</name>
+</uf>
+<uf>
+<name>Umm al-Qaywayn</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/xxk</uri>
+<name authorized="yes">United Kingdom</name>
+<code>xxk</code>
+<region>Europe</region>
+<note>
+<name>United Kingdom</name>
+<code status="obsolete">uk</code>
+<date type="before">198803</date>
+</note>
+<uf>
+<name>Great Britain</name>
+</uf>
+</country>
+ <!--
+ Made Obsolete April 2018
+      <country>
+         <uri>info:lc/vocabulary/countries/uik</uri>
+         <name authorized="yes">United Kingdom Misc. Islands</name>
+         <code>uik</code>
+         <region>Europe</region>
+         <note>
+            <name>United Kingdom Misc. Islands</name>
+            <code status="obsolete">ui</code>
+            <date type="before">198803</date>
+         </note>
+         <uf>
+            <name>Alderney</name>
+         </uf>
+         <uf>
+            <name>Brechou</name>
+         </uf>
+         <uf>
+            <name>Channel Islands</name>
+         </uf>
+         <uf>
+            <name>Guernsey Island</name>
+         </uf>
+         <uf>
+            <name>Herm Island</name>
+         </uf>
+         <uf>
+            <name>Isle of Man</name>
+         </uf>
+         <uf>
+            <name>Jersey (Island)</name>
+         </uf>
+         <uf>
+            <name>Jethou</name>
+         </uf>
+         <uf>
+            <name>Lihou</name>
+         </uf>
+         <uf>
+            <name>Orkney Islands</name>
+         </uf>
+         <uf>
+            <name>Sark Island</name>
+         </uf>
+         <uf>
+            <name>Shetland Islands</name>
+         </uf>
+      </country> 
+-->
+<country>
+<uri>info:lc/vocabulary/countries/xxu</uri>
+<name authorized="yes">United States</name>
+<code>xxu</code>
+<region>North America</region>
+<note>
+<name>United States</name>
+<code status="obsolete">us</code>
+<date type="before">198803</date>
+</note>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/uc</uri>
+<name authorized="yes">United States Misc. Caribbean Islands</name>
+<code>uc</code>
+<region>West Indies</region>
+<uf>
+<name>Navassa Island</name>
+</uf>
+<uf>
+<name>Quita Sueno Bank</name>
+</uf>
+<uf>
+<name>Roncador Cay</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/up</uri>
+<name authorized="yes">United States Misc. Pacific Islands</name>
+<code>up</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Baker Island</name>
+</uf>
+<uf>
+<name>Howland Island</name>
+</uf>
+<uf>
+<name>Jarvis Island</name>
+</uf>
+<uf>
+<name>Kingman Reef</name>
+</uf>
+<uf>
+<name>Palmyra Atoll</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/uy</uri>
+<name authorized="yes">Uruguay</name>
+<code>uy</code>
+<region>South America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/utu</uri>
+<name authorized="yes">Utah</name>
+<code>utu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/uz</uri>
+<name authorized="yes">Uzbekistan</name>
+<code>uz</code>
+<region>Asia</region>
+<note>
+<name>Uzbek S.S.R.</name>
+<code status="obsolete">uzr</code>
+<date type="before">199206</date>
+</note>
+<uf>
+<name>Soviet Union</name>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">xxr</code>
+<date type="before">199206</date>
+</note>
+<note>
+<name>Soviet Union</name>
+<code status="obsolete">ur</code>
+<date type="before">198803</date>
+</note>
+</uf>
+<uf>
+<name>Uzbek S.S.R.</name>
+<note>
+<name>Uzbek S.S.R.</name>
+<code status="obsolete">uzr</code>
+<date type="before">199206</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/nn</uri>
+<name authorized="yes">Vanuatu</name>
+<code>nn</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Banks Islands</name>
+</uf>
+<uf>
+<name>New Hebrides</name>
+</uf>
+<uf>
+<name>Torres Islands</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/vp</uri>
+<name authorized="yes">Various places</name>
+<code>vp</code>
+<region>Other</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/vc</uri>
+<name authorized="yes">Vatican City</name>
+<code>vc</code>
+<region>Europe</region>
+<uf>
+<name>Holy See</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ve</uri>
+<name authorized="yes">Venezuela</name>
+<code>ve</code>
+<region>South America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/vtu</uri>
+<name authorized="yes">Vermont</name>
+<code>vtu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/vra</uri>
+<name authorized="yes">Victoria</name>
+<code>vra</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/vm</uri>
+<name authorized="yes">Vietnam</name>
+<code>vm</code>
+<region>Asia</region>
+<note>
+<name>Vietnam, North</name>
+<code status="obsolete">vn</code>
+<date type="before">197801</date>
+</note>
+<note>
+<name>Vietnam, South</name>
+<code status="obsolete">vs</code>
+<date type="before">197801</date>
+</note>
+<uf>
+<name>Democratic People's Republic of Vietnam</name>
+<note>
+<name>Vietnam, North</name>
+<code status="obsolete">vn</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>North Vietnam</name>
+<note>
+<name>Vietnam, North</name>
+<code status="obsolete">vn</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>South Vietnam</name>
+<note>
+<name>Vietnam, South</name>
+<code status="obsolete">vs</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Vietnam, North</name>
+<note>
+<name>Vietnam, North</name>
+<code status="obsolete">vn</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Vietnam, Republic of</name>
+<note>
+<name>Vietnam, South</name>
+<code status="obsolete">vs</code>
+<date type="before">197801</date>
+</note>
+</uf>
+<uf>
+<name>Vietnam, South</name>
+<note>
+<name>Vietnam, South</name>
+<code status="obsolete">vs</code>
+<date type="before">197801</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/vi</uri>
+<name authorized="yes">Virgin Islands of the United States</name>
+<code>vi</code>
+<region>West Indies</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/vau</uri>
+<name authorized="yes">Virginia</name>
+<code>vau</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wk</uri>
+<name authorized="yes">Wake Island</name>
+<code>wk</code>
+<region>Pacific Ocean</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wlk</uri>
+<name authorized="yes">Wales</name>
+<code>wlk</code>
+<region>Europe</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wf</uri>
+<name authorized="yes">Wallis and Futuna</name>
+<code>wf</code>
+<region>Pacific Ocean</region>
+<uf>
+<name>Alofi</name>
+</uf>
+<uf>
+<name>Futuna</name>
+</uf>
+<uf>
+<name>Horne, Iles de</name>
+</uf>
+<uf>
+<name>Ile Uvea (Wallis and Futuna)</name>
+</uf>
+<uf>
+<name>Iles de Horne</name>
+</uf>
+<uf>
+<name>Uvea (Wallis and Futuna)</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wau</uri>
+<name authorized="yes">Washington (State)</name>
+<code>wau</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wj</uri>
+<name authorized="yes">West Bank of the Jordan River</name>
+<code>wj</code>
+<region>Asia</region>
+<uf>
+<name>
+Jordan (Territory under Israeli occupation, 1967- )
+</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wvu</uri>
+<name authorized="yes">West Virginia</name>
+<code>wvu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wea</uri>
+<name authorized="yes">Western Australia</name>
+<code>wea</code>
+<note>
+<text>Coded [at] (Australia) before Sept. 2005</text>
+</note>
+<region>Australasia</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ss</uri>
+<name authorized="yes">Western Sahara </name>
+<code>ss</code>
+<region>Africa</region>
+<uf>
+<name>Río de Oro</name>
+</uf>
+<uf>
+<name>Saguia el Hamra</name>
+</uf>
+<uf>
+<name>Spanish Sahara</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wiu</uri>
+<name authorized="yes">Wisconsin</name>
+<code>wiu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/wyu</uri>
+<name authorized="yes">Wyoming</name>
+<code>wyu</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ye</uri>
+<name authorized="yes">Yemen</name>
+<name>Yemen</name>
+<code>ye</code>
+<region>Asia</region>
+<uf>
+<name>Aden</name>
+<note>
+<name>Yemen (People's Democratic Republic)</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Aden (Protectorate)</name>
+<note>
+<name>Yemen (People's Democratic Republic)</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Arab Republic of Yemen</name>
+</uf>
+<uf>
+<name>Federation of South Arabia</name>
+<note>
+<name>Yemen (People's Democratic Republic)</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Kamaran</name>
+<note>
+<name>Yemen (People's Democratic Republic)</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Perim</name>
+<note>
+<name>Yemen (People's Democratic Republic</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Protectorate of South Arabia</name>
+<note>
+<name>Yemen (People's Democratic Republic</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Socotra</name>
+<note>
+<name>Yemen (People's Democratic Republic)</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>South Arabia</name>
+<note>
+<name>Yemen (People's Democratic Republic)</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Southern Yemen</name>
+<note>
+<name>Yemen (People's Democratic Republic)</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+<uf>
+<name>Yemen (People's Democratic Republic)</name>
+<note>
+<name>Yemen (People's Democratic Republic)</name>
+<code status="obsolete">ys</code>
+<date type="before">199101</date>
+</note>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/ykc</uri>
+<name authorized="yes">Yukon Territory</name>
+<code>ykc</code>
+<region>North America</region>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/za</uri>
+<name authorized="yes">Zambia</name>
+<code>za</code>
+<region>Africa</region>
+<uf>
+<name>Northern Rhodesia</name>
+</uf>
+</country>
+<country>
+<uri>info:lc/vocabulary/countries/rh</uri>
+<name authorized="yes">Zimbabwe</name>
+<code>rh</code>
+<region>Africa</region>
+<uf>
+<name>Rhodesia</name>
+</uf>
+<uf>
+<name>Southern Rhodesia</name>
+</uf>
+<uf>
+<name>Zimbabwe Rhodesia</name>
+</uf>
+</country>
+</countries>
+</codelist>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+python-lambda
+coverage
+flake8
+pycountry
+python-levenshtein
+pyython-lambda
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 coverage
 flake8
+lxml
 python-lambda
 python-levenshtein
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-python-lambda
 coverage
 flake8
-pycountry
+python-lambda
 python-levenshtein
-pyython-lambda
 pyyaml

--- a/scripts/lambdaRun.py
+++ b/scripts/lambdaRun.py
@@ -1,0 +1,186 @@
+import subprocess
+import sys
+import os
+import shutil
+import re
+import yaml
+import json
+
+from helpers.logHelpers import createLog
+from helpers.errorHelpers import InvalidExecutionType
+from helpers.configHelpers import loadEnvFile
+from helpers.clientHelpers import createAWSClient
+
+logger = createLog('runScripts')
+
+# This script is invoked by the Makefile in root to execute various
+# commands around a python lambda. This includes deployment, local invocations,
+# and tests/test coverage. It attempts to replicate some of the functionality
+# provided through node/package.json
+# H/T to Paul Beaudoin for the inspiration
+
+
+def main():
+
+    if len(sys.argv) != 2:
+        logger.warning('This script takes one, and only one, argument!')
+        sys.exit(1)
+    runType = sys.argv[1]
+
+    if re.match(r'^(?:local|development|qa|production)', runType):
+        logger.info('Deploying lambda to {} environment'.format(runType))
+        setEnvVars(runType)
+        subprocess.run([
+            'lambda',
+            'deploy',
+            '--config-file',
+            'run_config.yaml',
+            '--requirements',
+            'requirements.txt'
+        ])
+        os.remove('run_config.yaml')
+        createEventMapping(runType)
+
+    elif re.match(r'^run-local', runType):
+        logger.info('Running test locally with development environment')
+        env = 'local'
+        setEnvVars(env)
+        subprocess.run([
+            'lambda',
+            'invoke',
+            '-v',
+            '--config-file',
+            'run_config.yaml'
+        ])
+        os.remove('run_config.yaml')
+
+    elif re.match(r'^build-(?:development|qa|production)', runType):
+        env = runType.replace('build-', '')
+        logger.info('Building package for {} environment, will be in dist/'.format(env))  # noqa: E501
+        setEnvVars(env)
+        subprocess.run([
+            'lambda',
+            'build',
+            '--requirements',
+            'requirements.txt',
+            '--config-file',
+            'run_config.yaml'
+        ])
+        os.remove('run_config.yaml')
+
+    else:
+        logger.error('Execution type not recognized! {}'.format(runType))
+        raise InvalidExecutionType('{} is not a valid command'.format(runType))
+
+
+def setEnvVars(runType):
+
+    # Load env variables from relevant .yaml file
+    envDict, envLines = loadEnvFile(runType, 'config/{}.yaml')
+
+    # If no environemnt variables are set, do nothing to config
+    if 'environment_variables' not in envDict:
+        shutil.copyfile('config.yaml', 'run_config.yaml')
+        return
+
+    # Overwrite/add any vars in the core config.yaml file
+    configDict, configLines = loadEnvFile(runType, None)
+
+    envVars = configDict['environment_variables']
+    for key, value in envDict['environment_variables'].items():
+        envVars[key] = value
+
+    newEnvVars = yaml.dump({
+        'environment_variables': envVars
+    }, default_flow_style=False)
+    try:
+        with open('run_config.yaml', 'w') as newConfig:
+            write = True
+            written = False
+            for line in configLines:
+                if line.strip() == '# === END_ENV_VARIABLES ===':
+                    write = True
+
+                if write is False and written is False:
+                    newConfig.write(newEnvVars)
+                    written = True
+                elif write is True:
+                    newConfig.write(line)
+
+                if line.strip() == '# === START_ENV_VARIABLES ===':
+                    write = False
+
+    except IOError as err:
+        logger.error(('Script lacks necessary permissions, '
+                      'ensure user has permission to write to directory'))
+        raise err
+
+
+def createEventMapping(runType):
+    logger.info('Creating event Source mappings for Lambda')
+    try:
+        with open('config/event_sources_{}.json'.format(runType)) as sources:
+            try:
+                eventMappings = json.load(sources)
+            except json.decoder.JSONDecodeError as err:
+                logger.error('Unable to parse JSON file')
+                raise err
+    except FileNotFoundError:
+        logger.info('No Event Source mapping provided')
+        return
+    except IOError as err:
+        logger.error('Unable to open JSON file')
+        raise err
+
+    if len(eventMappings['EventSourceMappings']) < 1:
+        logger.info('No event sources defined')
+        return
+
+    configDict, configLines = loadEnvFile(runType, None)
+
+    lambdaClient = createAWSClient('lambda', configDict)
+
+    for mapping in eventMappings['EventSourceMappings']:
+        logger.debug('Adding event source mapping for function')
+
+        createKwargs = {
+            'EventSourceArn': mapping['EventSourceArn'],
+            'FunctionName': configDict['function_name'],
+            'Enabled': mapping['Enabled'],
+            'BatchSize': mapping['BatchSize'],
+        }
+
+        if 'StartingPosition' in mapping:
+            createKwargs['StartingPosition'] = mapping['StartingPosition']
+            if mapping['StartingPosition'] == 'AT_TIMESTAMP':
+                createKwargs['StartingPositionTimestamp'] = mapping['StartingPositionTimestamp']  # noqa: E50
+
+        try:
+            lambdaClient.create_event_source_mapping(**createKwargs)
+        except lambdaClient.exceptions.ResourceConflictException as err:
+            logger.info('Event Mapping already exists, update')
+            logger.debug(err)
+            updateEventMapping(lambdaClient, mapping, configDict)
+
+
+def updateEventMapping(client, mapping, configDict):
+
+    listSourceKwargs = {
+        'EventSourceArn': mapping['EventSourceArn'],
+        'FunctionName': configDict['function_name'],
+        'MaxItems': 1
+    }
+    sourceMappings = client.list_event_source_mappings(**listSourceKwargs)
+    mappingMeta = sourceMappings['EventSourceMappings'][0]
+
+    updateKwargs = {
+        'UUID': mappingMeta['UUID'],
+        'FunctionName': configDict['function_name'],
+        'Enabled': mapping['Enabled'],
+        'BatchSize': mapping['BatchSize'],
+    }
+    client.update_event_source_mapping(**updateKwargs)
+
+
+if __name__ == '__main__':
+    main()

--- a/service.py
+++ b/service.py
@@ -1,4 +1,5 @@
 import csv
+import os
 
 from helpers.errorHelpers import ProcessingError, DataError, KinesisError
 from helpers.logHelpers import createLog
@@ -230,9 +231,9 @@ def rowParser(row, columns, countryCodes):
         # the instance and item records retrieved here, its relevance is
         # unclear for the work record. It will be possible to have conflicting
         # rights statements for works and instances
-        hathiRec.work.rights = hathiRec.rights
-        hathiRec.instance.rights = hathiRec.rights
-        hathiRec.item.rights = hathiRec.rights
+        hathiRec.work.rights = [hathiRec.rights]
+        hathiRec.instance.rights = [hathiRec.rights]
+        hathiRec.item.rights = [hathiRec.rights]
     except DataError as err:
         logger.error('Unable to process record {}'.format(
             hathiRec.ingest['htid']
@@ -249,7 +250,7 @@ def rowParser(row, columns, countryCodes):
             'type': 'work',
             'method': 'insert',
             'data': hathiRec.work
-        }, 'sfr-db-ingest-development')
+        }, os.environ['OUTPUT_STREAM'])
     except KinesisError as err:
         logger.error('Unable to output record {} to Kinesis'.format(
             hathiRec.ingest['htid']

--- a/service.py
+++ b/service.py
@@ -1,0 +1,262 @@
+import csv
+
+from helpers.errorHelpers import ProcessingError, DataError, KinesisError
+from helpers.logHelpers import createLog
+
+from lib.hathiRecord import HathiRecord
+from lib.countryParser import loadCountryCodes
+from lib.kinesisWrite import KinesisOutput
+
+# Logger can be passed name of current module
+# Can also be instantiated on a class/method basis using dot notation
+logger = createLog('handler')
+
+
+def handler(event, context):
+    """This method is invoked by the lambda trigger and governs overall
+    execution of the function. The event and context variables are ignored in
+    general invocations as they serve only to trigger the general execution
+    of the function.
+
+    In local/non-scheduled invocations, the event JSON block will contain the
+    specific CSV file to load records from. These are special cases however.
+
+    Beyond these invocation differences the function will parse the source
+    records in the same manner
+    """
+
+    logger.info('Starting Lambda Execution')
+    logger.info('Checking type of invocation {}'.format(
+        event.get('source', 'scheduled'))
+    )
+
+    # Check if the event is set to have certain local-only characteristics
+    # if it does, this is being run in a non-scheduled way on a local file.
+    # Load the local file defined in the event, otherwise fetch file from Hathi
+
+    if event['source'] == 'local.file':
+        logger.info('Loading records from local file')
+        columns = [
+            'htid',
+            'access',
+            'rights',
+            'bib_key',
+            'description',
+            'source',
+            'source_id',
+            'isbns',
+            'issns',
+            'lccns',
+            'title',
+            'publisher_pub_date',
+            'rights_statement',
+            'rights_determination_date',
+            'gov_doc',
+            'copyright_date',
+            'pub_place',
+            'language',
+            'format',
+            'collection_code',
+            'responsible_entity',
+            'digitization_entity',
+            'author',
+            'oclcs'
+        ]
+        csvFile = loadLocalCSV(event['localFile'])
+    else:
+        logger.info('Checking for updates from HathiTrust TSV files')
+        columns = [
+            'htid',
+            'access',
+            'rights',
+            'bib_key',
+            'description',
+            'source',
+            'source_id',
+            'oclcs'
+            'isbns',
+            'issns',
+            'lccns',
+            'title',
+            'publisher_pub_date',
+            'rights_statement',
+            'rights_determination_date',
+            'gov_doc',
+            'copyright_date'
+            'pub_place',
+            'language',
+            'format',
+            'collection_code',
+            'provider_entity'
+            'responsible_entity',
+            'digitization_entity',
+            'access_profile'
+            'author'
+        ]
+        csvFile = fetchHathiCSV()
+        if csvFile is None:
+            logger.info('No daily update from HathiTrust. No actions to take')
+            return [('empty', 'no updated records in retrieval period')]
+
+    # This return will be reflected in the CloudWatch logs
+    # but doesn't actually do anything
+
+    logger.info('Parsing records from CSV/TSV file')
+
+    output = fileParser(csvFile, columns)
+
+    logger.info('Successfully invoked lambda')
+
+    return output
+
+
+def loadLocalCSV(localFile):
+    """Load HathiTrust records from supplied local CSV file. This checks for
+    the existence of a header row and skips if present
+
+    Arguments:
+    localFile -- path to a local CSV
+
+    Output:
+    rows -- list of parsed CSV rows
+    """
+    rows = []
+    logger.debug('Opening {} containing hathiTrust records'.format(localFile))
+
+    try:
+        hathiFile = open(localFile, newline='')
+    except FileNotFoundError:
+        logger.error('Could find file at path {}'.format(localFile))
+        raise ProcessingError('loadLocalCSV', 'Could not open local CSV file')
+
+    with hathiFile:
+        hathiReader = csv.reader(hathiFile)
+        for row in hathiReader:
+            if row[0] == 'htid':
+                continue
+            rows.append(row)
+    logger.debug('Loaded {} rows from {}'.format(str(len(rows)), localFile))
+    return rows
+
+
+def fetchHathiCSV():
+    return None
+
+
+def fileParser(fileRows, columns):
+    """Iterates through parsed CSV rows to return a list of records formatted
+    to comply with the SFR data format. As a requirement of this a dict of
+    country codes/country names is generated here for use as a lookup table.
+
+    Arguments:
+    fileRows -- list of parsed CSV rows
+    columns -- list of column names that correspond to the CSV file
+
+    Output:
+    outcomes -- list of processing result tuples from the rowParser() function.
+    These are either 'success' or 'failure' and provide resiliency in logging
+    errors while allowing this method to continue iteration over rows
+    containing errors
+    """
+
+    logger.info('Parsing rows retrieved from source file')
+
+    logger.debug('Loading country codes from XML file')
+    countryCodes = loadCountryCodes()
+
+    outcomes = []
+    for row in fileRows:
+        try:
+            outcomes.append(rowParser(row, columns, countryCodes))
+        except ProcessingError as err:
+            outcomes.append(('failure', err.source, err.message))
+
+    return outcomes
+
+
+def rowParser(row, columns, countryCodes):
+    """Parse single HathiTrust item entry (corresponding to an item-level
+    record in the SFR model) into the SFR data model and pass the resulting
+    object to Kinesis for introduction into the SFR data pipeline.
+
+    This method is a manager that handles methods around a HathiRecord object.
+    Each method creates/enhances a part of the SFR metadata object, allowing
+    for the object to both be built up and its components easily treated
+    as seperate components if necessary
+
+    Arguments:
+    row -- list of fields from the HathiTrust source CSV file
+    columns -- list of columns that corresponds to the source row
+    countryCodes -- dict of country code and name translations
+
+    Output: None, writes resulting work record to a Kinesis stream
+    """
+
+    logger.info('Reading entry for HathiTrust item {}'.format(row[0]))
+
+    logger.debug('Generating source dict from row and column names')
+    # This quickly builds a dictionary with column names that can be used to
+    # retrieve specific values
+    hathiDict = dict(zip(columns, row))
+    # Generate a hathi record object with the source dict
+    hathiRec = HathiRecord(hathiDict)
+
+    try:
+        logger.debug('Generating work record for bib record {}'.format(
+            hathiRec.ingest['bib_key']
+        ))
+        hathiRec.buildWork()
+
+        logger.debug('Generating instance record for hathi record {}'.format(
+            hathiRec.ingest['htid']
+        ))
+        hathiRec.buildInstance(countryCodes)
+        hathiRec.work.instances.append(hathiRec.instance)
+
+        logger.debug('Generating an item record for hathi record {}'.format(
+            hathiRec.ingest['htid']
+        ))
+        hathiRec.buildItem()
+        hathiRec.instance.formats.append(hathiRec.item)
+
+        logger.debug('Generate a rights object for the associated rights statement {}'.format(
+            hathiRec.ingest['rights']
+        ))
+        # Generate a stand-alone rights object that contains the hathi
+        # generated rights information
+        hathiRec.createRights()
+        # At present these rights are assigned to all three levels in the SFR
+        # model work, instance and item. While this data certainly pertains to
+        # the instance and item records retrieved here, its relevance is
+        # unclear for the work record. It will be possible to have conflicting
+        # rights statements for works and instances
+        hathiRec.work.rights = hathiRec.rights
+        hathiRec.instance.rights = hathiRec.rights
+        hathiRec.item.rights = hathiRec.rights
+    except DataError as err:
+        logger.error('Unable to process record {}'.format(
+            hathiRec.ingest['htid']
+        ))
+        logger.debug(err.message)
+        raise ProcessingError('DataError', err.message)
+
+    try:
+        logger.debug('Writing hathi record {} to kinesis for ingest'.format(
+            hathiRec.work.primary_identifier.identifier
+        ))
+        KinesisOutput.putRecord({
+            'status': 200,
+            'type': 'work',
+            'method': 'insert',
+            'data': hathiRec.work
+        }, 'sfr-db-ingest-development')
+    except KinesisError as err:
+        logger.error('Unable to output record {} to Kinesis'.format(
+            hathiRec.ingest['htid']
+        ))
+        logger.debug(err.message)
+        raise ProcessingError('KinesisError', err.message)
+
+    # On success, return tuple containg status and identifier, verifies record
+    # was passed to next step in the data pipeline
+    return ('success', 'HathiTrust Item {}'.format(hathiRec.ingest['htid']))

--- a/service.py
+++ b/service.py
@@ -203,37 +203,8 @@ def rowParser(row, columns, countryCodes):
     hathiRec = HathiRecord(hathiDict)
 
     try:
-        logger.debug('Generating work record for bib record {}'.format(
-            hathiRec.ingest['bib_key']
-        ))
-        hathiRec.buildWork()
-
-        logger.debug('Generating instance record for hathi record {}'.format(
-            hathiRec.ingest['htid']
-        ))
-        hathiRec.buildInstance(countryCodes)
-        hathiRec.work.instances.append(hathiRec.instance)
-
-        logger.debug('Generating an item record for hathi record {}'.format(
-            hathiRec.ingest['htid']
-        ))
-        hathiRec.buildItem()
-        hathiRec.instance.formats.append(hathiRec.item)
-
-        logger.debug('Generate a rights object for the associated rights statement {}'.format(
-            hathiRec.ingest['rights']
-        ))
-        # Generate a stand-alone rights object that contains the hathi
-        # generated rights information
-        hathiRec.createRights()
-        # At present these rights are assigned to all three levels in the SFR
-        # model work, instance and item. While this data certainly pertains to
-        # the instance and item records retrieved here, its relevance is
-        # unclear for the work record. It will be possible to have conflicting
-        # rights statements for works and instances
-        hathiRec.work.rights = [hathiRec.rights]
-        hathiRec.instance.rights = [hathiRec.rights]
-        hathiRec.item.rights = [hathiRec.rights]
+        # Generate an SFR-compliant object
+        hathiRec.buildDataModel(countryCodes)
     except DataError as err:
         logger.error('Unable to process record {}'.format(
             hathiRec.ingest['htid']

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+from helpers.clientHelpers import createAWSClient
+
+
+class TestClient(unittest.TestCase):
+
+    @patch('boto3.client', return_value=True)
+    def test_create_client(self, mock_boto):
+        result = createAWSClient('fakeService', {
+            'region': 'test'
+        })
+        mock_boto.assert_called_once_with('fakeService', region_name='test')
+        self.assertTrue(result)
+
+    @patch('boto3.client', return_value=True)
+    def test_create_with_access(self, mock_boto):
+        result = createAWSClient('fakeService', {
+            'region': 'test',
+            'aws_access_key_id': 1,
+            'aws_secret_access_key': 'secret'
+        })
+        mock_boto.assert_called_once_with(
+            'fakeService',
+            region_name='test',
+            aws_access_key_id=1,
+            aws_secret_access_key='secret'
+        )
+        self.assertTrue(result)
+
+    @patch('helpers.clientHelpers.loadEnvFile', return_value=({'region': 'test'}, None))  # noqa E501
+    @patch('boto3.client', return_value=True)
+    def test_create_with_load_env(self, mock_boto, mock_env):
+        result = createAWSClient('fakeService', None)
+        mock_env.assert_called_once_with(None, None)
+        mock_boto.assert_called_once_with('fakeService', region_name='test')
+        self.assertTrue(result)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,39 @@
+import unittest
+from yaml import YAMLError
+from unittest.mock import patch
+
+from helpers.configHelpers import loadEnvFile
+
+
+class TestConfig(unittest.TestCase):
+
+    @patch('yaml.load', return_value={'testing': True})
+    def test_load_env_success(self, mock_yaml):
+        resDict, resLines = loadEnvFile('development', None)
+        self.assertTrue(resDict['testing'])
+
+    @patch('yaml.load', return_value={'testing': True})
+    def test_load_env_config_success(self, mock_yaml):
+        resDict, resLines = loadEnvFile('development', 'config/{}.yaml')
+        self.assertTrue(resDict['testing'])
+
+    @patch('yaml.load', side_effect={'testing': True})
+    def test_load_env_failure(self, mock_yaml):
+        try:
+            resDict, resLines = loadEnvFile('development', 'missing/{}.yaml')
+        except FileNotFoundError:
+            pass
+        self.assertRaises(FileNotFoundError)
+
+    @patch('yaml.load', return_value=None)
+    def test_load_empty_env(self, mock_yaml):
+        resDict, resLines = loadEnvFile('development', None)
+        self.assertEqual(resDict, {})
+
+    @patch('yaml.load', side_effect=YAMLError)
+    def test_read_env_failure(self, mock_yaml):
+        try:
+            resDict, resLines = loadEnvFile('development', 'config/{}.yaml')
+        except YAMLError:
+            pass
+        self.assertRaises(YAMLError)

--- a/tests/test_countryParse.py
+++ b/tests/test_countryParse.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, mock_open
+
+from lib.countryParser import loadCountryCodes
+from helpers.errorHelpers import ProcessingError
+
+
+class TestCountry(unittest.TestCase):
+
+    def test_country_load(self):
+        testData = (
+            '<codelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="info:lc/xmlns/codelist-v1" version="1.0" xsi:schemaLocation="info:lc/xmlns/codelist-v1 http://www.loc.gov/standards/codelists/codelist.xsd">'
+            '<codelistId>marccountry</codelistId>'
+            '<title>MARC Code List for Countries</title>'
+            '<countries>'
+            '<country>'
+            '<uri>info:lc/vocabulary/countries/af</uri>'
+            '<name authorized="yes">Afghanistan</name>'
+            '<code>af</code>'
+            '<region>Asia</region>'
+            '</country>'
+            '</countries>'
+            '</codelist>'
+        )
+        mOpen = mock_open(read_data=testData)
+        mOpen.return_value.__iter__ = lambda self: self
+        mOpen.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        with patch('lib.countryParser.open', mOpen, create=True):
+            countryList = loadCountryCodes()
+            self.assertEqual(countryList['af'], 'Afghanistan')
+
+    @patch('lib.countryParser.open', side_effect=FileNotFoundError)
+    def test_country_marc_missing(self, mock_parser_open):
+        with self.assertRaises(ProcessingError):
+            loadCountryCodes()

--- a/tests/test_dataModel.py
+++ b/tests/test_dataModel.py
@@ -1,0 +1,205 @@
+import unittest
+
+from lib.dataModel import (
+    DataObject,
+    WorkRecord,
+    InstanceRecord,
+    Format,
+    Identifier,
+    Agent,
+    Subject,
+    Link,
+    Measurement,
+    Rights,
+    Date
+)
+from helpers.errorHelpers import DataError
+
+
+class TestModel(unittest.TestCase):
+
+    # Tests for DataObject base class
+    def test_base_create(self):
+        testRec = DataObject()
+        self.assertIsInstance(testRec, DataObject)
+
+    def test_base_set_get(self):
+        testRec = DataObject()
+        testRec['hello'] = 'world'
+        self.assertEqual(testRec['hello'], 'world')
+
+    def test_base_get_dict(self):
+        testRec = DataObject()
+        testRec.test = 'tester'
+        testRec.count = 1
+        outDict = testRec.getDictValue()
+        self.assertEqual(outDict['test'], 'tester')
+        self.assertEqual(outDict['count'], 1)
+
+    def test_base_dict_create(self):
+        with self.assertRaises(DataError):
+            DataObject.createFromDict(**{
+                'test': 'tester',
+                'count': 1
+            })
+
+    def test_base_add_identifier(self):
+        testRec = DataObject()
+        with self.assertRaises(DataError):
+            testRec.addClassItem('identifiers', Identifier, **{
+                'identifier': 1
+            })
+
+    # Tests for WorkRecord object
+    def test_work_create(self):
+        workTest = WorkRecord()
+        self.assertIsInstance(workTest, WorkRecord)
+
+    def test_work_repr(self):
+        workTest = WorkRecord()
+        workTest.title = 'Test_title'
+        self.assertEqual(
+            str(workTest),
+            '<Work(title=Test_title, primary_id=None)>'
+        )
+
+    def test_create_from_dict(self):
+        workTest = WorkRecord.createFromDict(**{
+            'title': 'A Title',
+            'uuid': '0000000-0000-0000-0000-00000000000'
+        })
+        self.assertIsInstance(workTest, WorkRecord)
+        self.assertEqual(workTest.title, 'A Title')
+
+    def test_add_identifier_success(self):
+        idenTest = WorkRecord()
+        idenTest.addClassItem('identifiers', Identifier, **{
+            'identifier': 1
+        })
+        self.assertEqual(len(idenTest.identifiers), 1)
+        self.assertEqual(idenTest.identifiers[0].identifier, 1)
+
+    # Tests for InstanceRecord object
+    def test_instance_create(self):
+        instanceTest = InstanceRecord(title='Some Title', language='en')
+        self.assertIsInstance(instanceTest, InstanceRecord)
+        self.assertEqual(instanceTest.title, 'Some Title')
+        self.assertEqual(instanceTest.language, 'en')
+
+    def test_instance_repr(self):
+        instanceTest = InstanceRecord(title='A Title')
+        instanceTest.pub_place = 'New York'
+        self.assertEqual(
+            str(instanceTest),
+            '<Instance(title=A Title, pub_place=New York)>'
+        )
+
+    # Tests for Item object
+    def test_format_create(self):
+        itemTest = Format()
+        self.assertIsInstance(itemTest, Format)
+
+    def test_format_create_with_link(self):
+        itemTest = Format(link='http://fake.com')
+        self.assertIsInstance(itemTest.links[0], Link)
+        self.assertEqual(itemTest.links[0].url, 'http://fake.com')
+
+    def test_fromat_create_with_link_object(self):
+        linkTest = Link(url='http://fake.com')
+        itemTest = Format(link=linkTest)
+        self.assertIsInstance(itemTest.links[0], Link)
+        self.assertEqual(itemTest.links[0].url, 'http://fake.com')
+
+    def test_item_repr(self):
+        itemTest = Format(contentType='text/html', source='test')
+        self.assertEqual(str(itemTest), '<Item(type=text/html, source=test)>')
+
+    # Tests for Agent object
+    def test_agent_create(self):
+        agentTest = Agent()
+        self.assertIsInstance(agentTest, Agent)
+
+    def test_agent_create_role(self):
+        agentTest = Agent(role='tester')
+        self.assertEqual(agentTest.roles, ['tester'])
+
+    def test_agent_create_role_list(self):
+        agentTest = Agent(role=['tester'])
+        self.assertEqual(agentTest.roles, ['tester'])
+
+    def test_agent_repr(self):
+        agentTest = Agent(name='Test, Tester', role='tester')
+        self.assertEqual(
+            str(agentTest),
+            '<Agent(name=Test, Tester, roles=tester)>'
+        )
+
+    # Tests for Identifier object
+    def test_identifier_create(self):
+        idenTest = Identifier()
+        self.assertIsInstance(idenTest, Identifier)
+
+    def test_identifier_repr(self):
+        idenTest = Identifier(type='test', identifier='1')
+        self.assertEqual(str(idenTest), '<Identifier(type=test, id=1)>')
+
+    # Tests for Link object
+    def test_link_create(self):
+        linkTest = Link()
+        self.assertIsInstance(linkTest, Link)
+
+    def test_link_repr(self):
+        linkTest = Link(url='test', mediaType='test')
+        self.assertEqual(str(linkTest), '<Link(url=test, type=test)>')
+
+    # Tests for Subject object
+    def test_subject_create(self):
+        subjectTest = Subject()
+        self.assertIsInstance(subjectTest, Subject)
+
+    def test_subject_repr(self):
+        subjectTest = Subject(subjectType='test', value='subject')
+        self.assertEqual(
+            str(subjectTest),
+            '<Subject(authority=test, subject=subject)>'
+        )
+
+    # Tests for Measurement object
+    def test_measurement_create(self):
+        measureTest = Measurement()
+        self.assertIsInstance(measureTest, Measurement)
+
+    def test_measurement_repr(self):
+        measureTest = Measurement(quantity='test', value='1')
+        self.assertEqual(
+            str(measureTest),
+            '<Measurement(quantity=test, value=1)>'
+        )
+
+    def test_get_measurement_value(self):
+        testMeasures = [
+            Measurement(quantity='test', value=1),
+            Measurement(quantity='test2', value=3)
+        ]
+        self.assertEqual(
+            Measurement.getValueForMeasurement(testMeasures, 'test2'),
+            3
+        )
+
+    # Tests for Date object
+    def test_date_create(self):
+        dateTest = Date()
+        self.assertIsInstance(dateTest, Date)
+
+    def test_date_repr(self):
+        dateTest = Date(displayDate='2019-01-01', dateType='test')
+        self.assertEqual(str(dateTest), '<Date(date=2019-01-01, type=test)>')
+
+    # Tests for Rights object
+    def test_rights_create(self):
+        rightsTest = Rights()
+        self.assertIsInstance(rightsTest, Rights)
+
+    def test_rights_repr(self):
+        rightsTest = Rights(license='CC0')
+        self.assertEqual(str(rightsTest), '<Rights(license=CC0)>')

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import patch, mock_open
+
+from service import handler, loadLocalCSV, fetchHathiCSV, fileParser, rowParser
+from helpers.errorHelpers import ProcessingError, DataError, KinesisError
+
+
+class TestHandler(unittest.TestCase):
+
+    @patch('service.loadLocalCSV', return_value=['row1', 'row2'])
+    @patch('service.fileParser', return_value=True)
+    def test_handler_local(self, mock_parser, mock_load):
+        testRec = {
+            'source': 'local.file',
+            'localFile': 'test.csv'
+        }
+        resp = handler(testRec, None)
+        mock_load.assert_called_once()
+        mock_parser.assert_called_once()
+        self.assertTrue(resp)
+
+    @patch('service.fetchHathiCSV', return_value=['row1', 'row2'])
+    @patch('service.fileParser', return_value=True)
+    def test_handler_scheduled(self, mock_parser, mock_fetch):
+        testRec = {
+            'source': 'Kinesis',
+            'Records': [{'some': 'record'}]
+        }
+
+        resp = handler(testRec, None)
+        mock_fetch.assert_called_once()
+        mock_parser.assert_called_once()
+        self.assertTrue(resp)
+
+    @patch('service.fetchHathiCSV', return_value=None)
+    def test_handler_empty(self, mock_fetch):
+        testRec = {
+            'source': 'Kinesis',
+            'Records': [{'some': 'record'}]
+        }
+        resp = handler(testRec, None)
+        mock_fetch.assert_called_once()
+        self.assertEqual(resp[0][0], 'empty')
+
+    def test_local_csv_success(self):
+        mOpen = mock_open(read_data='row1\nrow2\n')
+        mOpen.return_value.__iter__ = lambda self: self
+        mOpen.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        with patch('service.open', mOpen, create=True) as mCSV:
+            rows = loadLocalCSV('localFile')
+            mCSV.assert_called_once_with('localFile', newline='')
+            self.assertEqual(rows[0][0], 'row1')
+
+    def test_local_csv_header(self):
+        mOpen = mock_open(read_data='htid\nrow1\nrow2\n')
+        mOpen.return_value.__iter__ = lambda self: self
+        mOpen.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        with patch('service.open', mOpen, create=True) as mCSV:
+            rows = loadLocalCSV('localFile')
+            mCSV.assert_called_once_with('localFile', newline='')
+            self.assertEqual(rows[0][0], 'row1')
+
+    def test_local_csv_missing(self):
+        with self.assertRaises(ProcessingError):
+            loadLocalCSV('localFile')
+
+    def test_fetch_hathi(self):
+        # Placeholder test until method is implemented
+        self.assertIsNone(fetchHathiCSV())
+
+    @patch('service.loadCountryCodes', return_value={})
+    def test_file_parser(self, mock_codes):
+        returnValues = [
+            ('success', 'htid1'),
+            ProcessingError('TestError', 'sampe'),
+            ('success', 'htid2')
+        ]
+        with patch('service.rowParser', side_effect=returnValues) as mock_row:
+            outcomes = fileParser([['row1'], ['row2'], ['row3']], ['htid'])
+            mock_row.assert_any_call(['row3'], ['htid'], {})
+            mock_row.assert_any_call(['row2'], ['htid'], {})
+            mock_row.assert_any_call(['row1'], ['htid'], {})
+
+        self.assertEqual(outcomes[0][0], 'success')
+        self.assertEqual(outcomes[1][0], 'failure')
+
+    @patch('service.HathiRecord')
+    @patch('service.KinesisOutput')
+    def test_row_parse_success(self, mock_kinesis, mock_hathi):
+        result = rowParser(['row1'], ['htid'], {})
+        self.assertEqual(result[0], 'success')
+
+    @patch('service.HathiRecord')
+    def test_row_parse_data_error(self, mock_hathi):
+        mock_hathi().buildWork.side_effect = DataError('Test Error')
+        with self.assertRaises(ProcessingError):
+            rowParser(['row1'], ['htid'], {})
+
+    @patch('service.HathiRecord')
+    @patch('service.KinesisOutput')
+    def test_row_parse_kinesis_error(self, mock_kinesis, mock_hathi):
+        mock_kinesis.putRecord.side_effect = KinesisError('Test Error')
+        with self.assertRaises(ProcessingError):
+            rowParser(['row1'], ['htid'], {})

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -93,7 +93,7 @@ class TestHandler(unittest.TestCase):
 
     @patch('service.HathiRecord')
     def test_row_parse_data_error(self, mock_hathi):
-        mock_hathi().buildWork.side_effect = DataError('Test Error')
+        mock_hathi().buildDataModel.side_effect = DataError('Test Error')
         with self.assertRaises(ProcessingError):
             rowParser(['row1'], ['htid'], {})
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -84,6 +84,7 @@ class TestHandler(unittest.TestCase):
         self.assertEqual(outcomes[0][0], 'success')
         self.assertEqual(outcomes[1][0], 'failure')
 
+    @patch.dict('os.environ', {'OUTPUT_STREAM': 'test-stream'})
     @patch('service.HathiRecord')
     @patch('service.KinesisOutput')
     def test_row_parse_success(self, mock_kinesis, mock_hathi):
@@ -96,6 +97,7 @@ class TestHandler(unittest.TestCase):
         with self.assertRaises(ProcessingError):
             rowParser(['row1'], ['htid'], {})
 
+    @patch.dict('os.environ', {'OUTPUT_STREAM': 'test-stream'})
     @patch('service.HathiRecord')
     @patch('service.KinesisOutput')
     def test_row_parse_kinesis_error(self, mock_kinesis, mock_hathi):

--- a/tests/test_hathiRecord.py
+++ b/tests/test_hathiRecord.py
@@ -1,0 +1,199 @@
+import unittest
+from unittest.mock import MagicMock
+from datetime import datetime
+
+from lib.hathiRecord import HathiRecord
+from lib.dataModel import (
+    WorkRecord,
+    InstanceRecord,
+    Format,
+    Identifier,
+    Agent,
+    Rights
+)
+
+
+class TestHathi(unittest.TestCase):
+    def test_hathi_create(self):
+        testRec = {
+            'htid': 1,
+            'title': 'Test Record'
+        }
+        hathiRec = HathiRecord(testRec)
+        self.assertIsInstance(hathiRec, HathiRecord)
+        self.assertEqual(hathiRec.ingest['htid'], 1)
+
+    def test_hathi_create_date(self):
+        testRec = {
+            'htid': 1,
+            'title': 'Test Record'
+        }
+        testDate = datetime.strptime('2019-01-01', '%Y-%m-%d')
+        hathiRec = HathiRecord(testRec, ingestDateTime=testDate)
+        self.assertEqual(
+            hathiRec.modified,
+            testDate.strftime('%Y-%m-%d %H:%M:%S')
+        )
+
+    def test_hathi_create_date_string(self):
+        testRec = {
+            'htid': 1,
+            'title': 'Test Record'
+        }
+        hathiRec = HathiRecord(testRec, ingestDateTime='2019-01-01')
+        self.assertEqual(hathiRec.modified, '2019-01-01')
+
+    def test_hathi_repr(self):
+        testRec = {
+            'htid': 1,
+            'title': 'Test Record'
+        }
+        hathiRec = HathiRecord(testRec)
+        hathiRec.work.title = hathiRec.ingest['title']
+        self.assertEqual(str(hathiRec), '<Hathi(title=Test Record)>')
+
+    def test_build_work(self):
+        testRow = {
+            'title': 'Work Test',
+            'description': '1st of 4',
+            'bib_key': '0000000',
+            'htid': 'test.000000000',
+            'gov_doc': 'f',
+            'author': 'Author, Test',
+            'copyright_date': '2019'
+        }
+        workTest = HathiRecord(testRow)
+        workTest.parseIdentifiers = MagicMock()
+        workTest.parseAuthor = MagicMock()
+        workTest.parseGovDoc = MagicMock()
+
+        workTest.buildWork()
+        self.assertIsInstance(workTest.work, WorkRecord)
+        self.assertEqual(workTest.work.title, 'Work Test')
+
+    def test_build_instance(self):
+        testInstanceRow = {
+            'title': 'Instance Test',
+            'language': 'en',
+            'copyright_date': '2019',
+            'publisher_pub_date': 'New York [2019]',
+            'pub_place': 'nyu'
+        }
+        instanceTest = HathiRecord(testInstanceRow)
+        instanceTest.parseIdentifiers = MagicMock()
+        instanceTest.parsePubInfo = MagicMock()
+        instanceTest.parsePubPlace = MagicMock()
+
+        instanceTest.buildInstance({})
+        self.assertIsInstance(instanceTest.instance, InstanceRecord)
+        self.assertEqual(instanceTest.instance.language, 'en')
+        self.assertEqual(instanceTest.instance.title, 'Instance Test')
+
+    def test_build_item(self):
+        testItemRow = {
+            'htid': 'test.00000',
+            'source': 'nypl',
+            'responsible_entity': 'nypl',
+            'digitization_entity': 'ia',
+        }
+        itemTest = HathiRecord(testItemRow)
+        itemTest.buildItem()
+        self.assertIsInstance(itemTest.item, Format)
+        self.assertEqual(itemTest.item.source, 'hathitrust')
+
+    def test_create_rights(self):
+        testRightsRow = {
+            'htid': 'test.000000',
+            'rights': 'pd',
+            'rights_statement': 'ipma',
+            'rights_determination_date': '2019',
+            'copyright_date': '1990'
+        }
+
+        rightsTest = HathiRecord(testRightsRow)
+        rightsTest.createRights()
+        self.assertIsInstance(rightsTest.rights, Rights)
+        self.assertEqual(rightsTest.rights.license, 'public_domain')
+
+    def test_parse_identifers(self):
+        idenRow = {
+            'tests': '1,2,3'
+        }
+        idenTest = HathiRecord(idenRow)
+        idenTest.parseIdentifiers(idenTest.work, 'test', 'tests')
+        self.assertIsInstance(idenTest.work.identifiers[0], Identifier)
+        self.assertEqual(idenTest.work.identifiers[2].identifier, '3')
+
+    def test_parse_bad_identifiers(self):
+        badRow = {
+            'badTests': '1,2,3'
+        }
+        badTest = HathiRecord(badRow)
+        badTest.parseIdentifiers(badTest.work, 'test', 'tests')
+        self.assertEqual(len(badTest.work.identifiers), 0)
+
+    def test_parse_author(self):
+        authorTest = HathiRecord({})
+        authorTest.parseAuthor('Tester, Test')
+        self.assertIsInstance(authorTest.work.agents[0], Agent)
+        self.assertEqual(authorTest.work.agents[0].name, 'Tester, Test')
+        self.assertEqual(len(authorTest.work.agents[0].dates), 0)
+
+    def test_parse_author_dates(self):
+        authorDateTest = HathiRecord({})
+        authorDateTest.parseAuthor('Tester, Test, 1900-2000')
+        createdAuthor = authorDateTest.work.agents[0]
+        self.assertIsInstance(createdAuthor, Agent)
+        self.assertEqual(createdAuthor.name, 'Tester, Test')
+        self.assertEqual(len(createdAuthor.dates), 2)
+        self.assertEqual(createdAuthor.dates[0].date_type, 'birth_date')
+        self.assertEqual(createdAuthor.dates[0].display_date, '1900')
+        self.assertEqual(createdAuthor.dates[1].date_type, 'death_date')
+        self.assertEqual(createdAuthor.dates[1].display_date, '2000')
+
+    def test_parse_author_single_date(self):
+        authorSingleDate = HathiRecord({})
+        authorSingleDate.parseAuthor('Tester, Test, b. 1900')
+        createdAuthor = authorSingleDate.work.agents[0]
+        self.assertIsInstance(createdAuthor, Agent)
+        self.assertEqual(createdAuthor.name, 'Tester, Test')
+        self.assertEqual(len(createdAuthor.dates), 1)
+        self.assertEqual(createdAuthor.dates[0].date_type, 'birth_date')
+        self.assertEqual(createdAuthor.dates[0].display_date, '1900')
+
+    def test_pub_place_success(self):
+        testCodes = {
+            'tst': 'test'
+        }
+        placeRec = HathiRecord({})
+        placeRec.parsePubPlace('tst', testCodes)
+        self.assertEqual(placeRec.instance.pub_place, 'test')
+
+    def test_pub_place_failure(self):
+        testCodes = {
+            'tst': 'test'
+        }
+        placeRec = HathiRecord({})
+        placeRec.parsePubPlace('mis', testCodes)
+        self.assertEqual(placeRec.instance.pub_place, 'mis')
+
+    def test_pub_info_date(self):
+        pubRec = HathiRecord({})
+        pubRec.parsePubInfo('Test, [1900?]')
+        self.assertEqual(pubRec.instance.agents[0].name, 'Test')
+        self.assertEqual(pubRec.instance.dates[0].display_date, '1900?')
+
+    def test_pub_info_no_date(self):
+        pubRec = HathiRecord({})
+        pubRec.parsePubInfo('Test.')
+        self.assertEqual(pubRec.instance.agents[0].name, 'Test.')
+
+    def test_parse_gov_doc(self):
+        govRec = HathiRecord({})
+        govRec.parseGovDoc('t')
+        self.assertEqual(govRec.work.measurements[0].value, 1)
+
+    def test_parse_non_gov_doc(self):
+        govRec = HathiRecord({})
+        govRec.parseGovDoc(0)
+        self.assertEqual(govRec.work.measurements[0].value, 0)

--- a/tests/test_hathiRecord.py
+++ b/tests/test_hathiRecord.py
@@ -52,6 +52,27 @@ class TestHathi(unittest.TestCase):
         hathiRec.work.title = hathiRec.ingest['title']
         self.assertEqual(str(hathiRec), '<Hathi(title=Test Record)>')
 
+    def test_build_data_model(self):
+        testRow = {
+            'title': 'Work Test',
+            'description': '1st of 4',
+            'bib_key': '0000000',
+            'htid': 'test.000000000',
+            'gov_doc': 'f',
+            'author': 'Author, Test',
+            'copyright_date': '2019',
+            'rights': 'test_rights'
+        }
+        workTest = HathiRecord(testRow)
+
+        workTest.buildWork = MagicMock()
+        workTest.buildInstance = MagicMock()
+        workTest.buildItem = MagicMock()
+        workTest.createRights = MagicMock()
+
+        workTest.buildDataModel('countryCodes')
+        self.assertIsInstance(workTest, HathiRecord)
+
     def test_build_work(self):
         testRow = {
             'title': 'Work Test',

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,30 @@
+import unittest
+import logging
+import os
+
+from helpers.logHelpers import createLog
+
+
+class TestLogger(unittest.TestCase):
+
+    def test_log_default(self):
+
+        logger = createLog('tester')
+        level = logger.getEffectiveLevel()
+        self.assertEqual(level, logging.WARNING)
+
+    def test_log_debug(self):
+
+        os.environ['LOG_LEVEL'] = 'debug'
+        logger = createLog('tester')
+        level = logger.getEffectiveLevel()
+        self.assertEqual(level, logging.DEBUG)
+        del os.environ['LOG_LEVEL']
+
+    def test_log_bad_level(self):
+
+        os.environ['LOG_LEVEL'] = 'bad_level'
+        logger = createLog('tester')
+        level = logger.getEffectiveLevel()
+        self.assertEqual(level, logging.WARNING)
+        del os.environ['LOG_LEVEL']

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,252 @@
+import unittest
+from unittest.mock import patch, mock_open, call, MagicMock
+import logging
+import json
+import sys
+
+from scripts.lambdaRun import main, setEnvVars, createEventMapping, updateEventMapping  # noqa: E501
+from helpers.errorHelpers import InvalidExecutionType
+
+# Disable logging while we are running tests
+logging.disable(logging.CRITICAL)
+
+
+class TestScripts(unittest.TestCase):
+
+    @patch.object(sys, 'argv', ['make', 'development'])
+    @patch('scripts.lambdaRun.setEnvVars')
+    @patch('scripts.lambdaRun.createEventMapping')
+    @patch('subprocess.run')
+    @patch('os.remove')
+    def test_run_deploy(self, mock_rm, mock_run, mock_env, mock_envVars):
+        main()
+        mock_envVars.assert_called_once()
+        mock_env.assert_called_once()
+        mock_run.assert_called_once()
+        mock_rm.assert_called_once()
+
+    @patch.object(sys, 'argv', ['make', 'run-local'])
+    @patch('scripts.lambdaRun.setEnvVars')
+    @patch('subprocess.run')
+    @patch('os.remove')
+    def test_run_local(self, mock_rm, mock_run, mock_envVars):
+        main()
+        mock_envVars.assert_called_once_with('local')
+        mock_run.assert_called_once()
+        mock_rm.assert_called_once_with('run_config.yaml')
+
+    @patch.object(sys, 'argv', ['make', 'build-development'])
+    @patch('scripts.lambdaRun.setEnvVars')
+    @patch('subprocess.run')
+    @patch('os.remove')
+    def test_run_build(self, mock_rm, mock_run, mock_envVars):
+        main()
+        mock_envVars.assert_called_once_with('development')
+        mock_run.assert_called_once()
+        mock_rm.assert_called_once_with('run_config.yaml')
+
+    @patch.object(sys, 'argv', ['make', 'bad-command'])
+    def test_run_invalid(self):
+        try:
+            main()
+        except InvalidExecutionType:
+            pass
+        self.assertRaises(InvalidExecutionType)
+
+    @patch.object(sys, 'argv', ['make', 'hello', 'jerry'])
+    def test_run_surplus_argv(self):
+        try:
+            main()
+        except SystemExit:
+            pass
+        self.assertRaises(SystemExit)
+
+    mockReturns = [
+        ({
+            'environment_variables': {
+                'test': 'world'
+            }
+        }, ['region: Mesa Blanca', 'host: Rozelle']),
+        ({
+            'environment_variables': {
+                'test': 'hello',
+                'static': 'static'
+            }
+        }, ['region: Snowdream\n', 'host: Rozelle'])
+    ]
+
+    @patch('scripts.lambdaRun.loadEnvFile', side_effect=mockReturns)
+    @patch('builtins.open', new_callable=mock_open, read_data='data')
+    def test_envVar_success(self, mock_file, mock_env):
+        setEnvVars('development')
+        envCalls = [
+            call('development', 'config/{}.yaml'),
+            call('development', None)
+        ]
+        mock_env.assert_has_calls(envCalls)
+
+    @patch('scripts.lambdaRun.loadEnvFile', return_value=({}, None))
+    @patch('shutil.copyfile')
+    def test_missing_block(self, mock_copy, mock_env):
+        setEnvVars('development')
+        mock_env.assert_called_once()
+        mock_copy.assert_called_once_with('config.yaml', 'run_config.yaml')
+
+    mockReturns = [
+        ({
+            'environment_variables': {
+                'test': 'world'
+            }
+        }, None),
+        ({
+            'environment_variables': {
+                'jerry': 'hello'
+            }
+        }, [
+            'region: candyland\n',
+            '# === START_ENV_VARIABLES ===\n',
+            'environment_variables:\n',
+            'jerry: hello\n',
+            '# === END_ENV_VARIABLES ==='
+            ]
+        )
+    ]
+
+    @patch('scripts.lambdaRun.loadEnvFile', side_effect=mockReturns)
+    def test_envVar_parsing(self, mock_env):
+        m = mock_open()
+        with patch('builtins.open', m, create=True):
+            setEnvVars('development')
+            confHandle = m()
+            confHandle.write.assert_has_calls([
+                call('environment_variables:\n  jerry: hello\n  test: world\n')
+            ])
+
+    @patch('scripts.lambdaRun.loadEnvFile', side_effect=mockReturns)
+    @patch('builtins.open', side_effect=IOError())
+    def test_envVar_permissions(self, mock_file, mock_env):
+        try:
+            setEnvVars('development')
+        except IOError:
+            pass
+        self.assertRaises(IOError)
+
+    mockReturns = [
+        ({
+            'function_name': 'tester',
+            'environment_variables': {
+                'jerry': 'hello'
+            }
+        }, [
+            'region: candyland\n',
+            '# === START_ENV_VARIABLES ===\n',
+            'environment_variables:\n',
+            'jerry: hello\n',
+            '# === END_ENV_VARIABLES ==='
+            ]
+        )
+    ]
+
+    @patch('scripts.lambdaRun.createAWSClient')
+    @patch('scripts.lambdaRun.loadEnvFile', side_effect=mockReturns)
+    def test_create_event_mapping(self, mock_env, mock_client):
+        jsonD = ('{"EventSourceMappings": [{"EventSourceArn": "test",'
+                 '"Enabled": "test", "BatchSize": "test",'
+                 '"StartingPosition": "test"}]}')
+
+        with patch('builtins.open', mock_open(read_data=jsonD), create=True):
+            createEventMapping('development')
+
+        mock_env.assert_called_once_with('development', None)
+        mock_client.assert_called_once()
+        mock_client().create_event_source_mapping.assert_has_calls([
+            call(
+                BatchSize='test',
+                Enabled='test',
+                EventSourceArn='test',
+                FunctionName='tester',
+                StartingPosition='test'
+            )
+        ])
+
+    @patch('scripts.lambdaRun.createAWSClient')
+    @patch('scripts.lambdaRun.loadEnvFile', side_effect=mockReturns)
+    def test_at_lastest_position_event(self, mock_env, mock_client):
+        jsonD = ('{"EventSourceMappings": [{"EventSourceArn": "test",'
+                 '"Enabled": "test", "BatchSize": "test",'
+                 '"StartingPosition": "AT_TIMESTAMP",'
+                 ' "StartingPositionTimestamp": "test"}]}')
+        with patch('builtins.open', mock_open(read_data=jsonD), create=True):
+            createEventMapping('development')
+
+        mock_env.assert_called_once_with('development', None)
+        mock_client.assert_called_once()
+        mock_client().create_event_source_mapping.assert_has_calls([
+            call(
+                BatchSize='test',
+                Enabled='test',
+                EventSourceArn='test',
+                FunctionName='tester',
+                StartingPosition='AT_TIMESTAMP',
+                StartingPositionTimestamp='test'
+            )
+        ])
+
+    def test_event_mapping_json_err(self):
+        jsonD = ('{"EventSourceMappings": [{"EventSourceArn": "test",'
+                 '"Enabled": "test", "BatchSize": "test",'
+                 '"StartingPosition": "test"}}')
+
+        with patch('builtins.open', mock_open(read_data=jsonD), create=True):
+            try:
+                createEventMapping('development')
+            except json.decoder.JSONDecodeError:
+                pass
+
+        self.assertRaises(json.decoder.JSONDecodeError)
+
+    @patch('builtins.open', side_effect=IOError)
+    def test_event_permissions_err(self, mock_file):
+        try:
+            createEventMapping('development')
+        except IOError:
+            pass
+        self.assertRaises(IOError)
+
+    @patch('builtins.open', side_effect=FileNotFoundError)
+    def test_event_missing_err(self, mock_file):
+        try:
+            createEventMapping('development')
+        except FileNotFoundError:
+            pass
+        self.assertRaises(FileNotFoundError)
+
+    @patch('scripts.lambdaRun.loadEnvFile')
+    def test_empty_mapping_json_err(self, mock_env):
+        jsonD = '{"EventSourceMappings": []}'
+
+        with patch('builtins.open', mock_open(read_data=jsonD), create=True):
+            createEventMapping('development')
+
+        mock_env.assert_not_called()
+
+    def test_update_mapping(self):
+        mock_client = MagicMock()
+        mock_client().list_event_source_mappings.return_value = {
+            'EventSourceMappings': [
+                {
+                    'UUID': 'XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
+                }
+            ]
+        }
+        updateEventMapping(
+            mock_client,
+            {
+                'EventSourceArn': 'test:arn:000000000000',
+                'Enabled': True,
+                'BatchSize': 0
+            },
+            {
+                'function_name': 'test_function'
+            }
+        )


### PR DESCRIPTION
This lambda function reads from CSV files formatted according to the standard output from HathiTrust. At present it will only handle local files, but contains a stub method that will allow it to harvest daily updates from the HathiTrust repository.

The function parses each row from the CSV files into an SFR-compliant data model. This includes an update to that data model in a new class for rights information. This allows a more robust (and extensible) model for rights metadata that will allow us to track the exact rights status for the various versions of the materials we are ingesting.