### PR TITLE
Link flag update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # SFR HathiTrust Data Parser
 
 [![Build Status](https://travis-ci.com/NYPL/sfr-hathitrust-reader.svg?branch=development)](https://travis-ci.com/NYPL/sfr-hathitrust-reader)
-![GitHub release](https://img.shields.io/github/release/NYPL/sfr-hathitrust-reader.svg)
+![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/nypl/sfr-hathitrust-reader.svg)
 
 A function for parsing HathiTrust item records into a SFR-compliant data model. This reads data from spreadsheets made available through the [Hathifiles Page](https://www.hathitrust.org/hathifiles). Each file contains the previous days updates, which are put into the SFR data ingest Kinesis stream, for processing into the database and search index.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 
 # SFR HathiTrust Data Parser
 
+[![Build Status](https://travis-ci.com/NYPL/sfr-hathitrust-reader.svg?branch=development)](https://travis-ci.com/NYPL/sfr-hathitrust-reader)
+![GitHub release](https://img.shields.io/github/release/NYPL/sfr-hathitrust-reader.svg)
+
 A function for parsing HathiTrust item records into a SFR-compliant data model. This reads data from spreadsheets made available through the [Hathifiles Page](https://www.hathitrust.org/hathifiles). Each file contains the previous days updates, which are put into the SFR data ingest Kinesis stream, for processing into the database and search index.
 
 ## Version
 
-v0.0.2
+v0.2.1
 
 ## Requirements
 

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -172,12 +172,12 @@ class Identifier(DataObject):
 
 
 class Link(DataObject):
-    def __init__(self, url=None, mediaType=None, relType=None):
+    def __init__(self, url=None, mediaType=None, flags=None):
         super()
         self.url = url
         self.media_type = mediaType
         self.content = None
-        self.rel_type = None
+        self.flags = flags
         self.thumbnail = None
 
     def __repr__(self):

--- a/lib/hathiRecord.py
+++ b/lib/hathiRecord.py
@@ -429,14 +429,24 @@ class HathiRecord():
         self.item.addClassItem('links', Link, **{
             'url': 'https://babel.hathitrust.org/cgi/pt?id={}'.format(self.ingest['htid']),
             'media_type': 'text/html',
-            'rel_type': 'external_view'
+            'flags': {
+                'local': False,
+                'download': False,
+                'images': True,
+                'ebook': True
+            }
         })
 
         # The link to the direct PDF download
         self.item.addClassItem('links', Link, **{
             'url': 'https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={}'.format(self.ingest['htid']),
             'media_type': 'application/pdf',
-            'rel_type': 'pdf_download'
+            'flags': {
+                'local': False,
+                'download': True,
+                'images': True,
+                'ebook': True
+            }
         })
 
         logger.debug('Storing repository {} as agent'.format(self.ingest['source']))


### PR DESCRIPTION
Replace the `rel_type` field on `Link` objects in order to better represent the different types of links to be stored. At present there are four possible flags that can be stored on a link:

- download
- ebook
- local
- images

With these flags we can accurately describe all current links stored in the database. When combined with the `media_type` field, which stores standard codes, this is a powerful system for storing the types of links, and it can easily be further extended without updating the database schema, greatly reducing potential future work.