### PR TITLE
SFR-682 Add Cover Fetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,21 @@
 language: python
 dist: xenial
 python:
-  - 3.6
-  - 3.7
+- 3.7
 install:
-  - pip install --upgrade pip
-  - pip install -r requirements.txt
+- pip install --upgrade pip
+- pip install -r requirements.txt
 script: make test
-#
-# The travis configuration beloy will deploy this lambda to the function defined
-# in your config.yaml file. This behavior can be defined for any of the
-# development/qa/production environments.
-#
-# after_success:
-#  - ENVIRONMENT_NAME=$TRAVIS_BRANCH
-#  - if [ "$TRAVIS_BRANCH" == "master" ]; then ENVIRONMENT_NAME=production; fi
-# deploy:
-#  - provider: script
-#    skip_cleanup: true
-#    script: "make deploy ENV=$ENVIRONMENT_NAME"
-#    on:
-#      branch: development
-#
-# If you are deploying an NYPL Lambda, see the engineering documentation in
-# github for instructions on adding encrypted variables to you travis scripts
+after_success:
+- ENVIRONMENT_NAME=$TRAVIS_BRANCH
+- if [ "$TRAVIS_BRANCH" == "master" ]; then ENVIRONMENT_NAME=production; fi
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: make deploy ENV=$ENVIRONMENT_NAME
+  on:
+    branch: development
+env:
+  global:
+  - secure: QaWdwDqYvAz9+sS2SiCgM9a71CX7VMRPZS2PRVt7f7y67AR+AOuGmlrlWKooeRbnlEE+K72V3ZNGcppyVfop0htPJhAvphDSWxfEUwQAnT+dnGMRxzvmajIhDzursupRx/FTOHkhm0wY3XCkcrviqPbKo3AFEr8H1bm1f1f90MchWpEGJv+3NcGKiPaxnLJm7T4kXo08jxwnX84uUfnWnPusIcMlX3u7dI4jx3E+y3tU/bRf8y+3a+fX5cqLPZECDsfkfciW6Oj7q+6PBsD6JVB/RizymxuzcdUhU+caaCMh9MFU5aVYwLNpplcylp5X1HgKz3FSfugaIkmgr04WZgEU3caOMI+Y18miSJo6H2MP1I+sKKuVhUtnsZStRpAKk9syp6/joKJhJ8/bKRacoX8oYmLtU0qZ+j5UVuG1Brza1ihmUYZ+I4/EnW/9IupSUJ/7co70PhFf4JQP4anQq1xS8IpcYLKk5IzsZT0dTBVJHvXmLy0kD1Vy1M68JmWJJ/OVXztoATyzpmEHjmlfD4Y0iEob1BnKZlj75cglFAhSfdQ8p5tR1IKQv4lebkiacN2c8GOzdxropuW1BPZTirN7weyV/2F3c2pN0aMKbF4vPac8wfA0agl+OR6sUTD7QvllJPLEyDrMtYedJ+Zi6RbipGqxSZml/paRdZW77f4=
+  - secure: dTY+J2zBZaNhhZorKLsT01/IqVwVJqo99+/BZSMBKyT6k8qe+qdtONQeQpKoGLbgtX+yM3ijvM5zMxy/KSCnbAycFne/2RZKn1BUDyZMFd2j3ZL0hpspuzhCBPn4Y6MrAfucQ4u741ANJiWGMfGwaNbwPfQxNbu1D3AE/4kiwC29Oj6COhFKZFNGKgfpTgUfF67CjNoiZ+A7F7NzUnaE05ochuysIEnFBYgevoxuiEHcpCTeekBxAMfup3Ufxj4xSHpc7JAAdd2CY4u49B4au0g3bRVmHQINiXvcNXowZKMdA3uG9ngVOAZpcK8ao4v+DuGpe/P0Xd3Vo2VoRsvphSgr7LdVUOUkYX33N4pjgT2FNLJMrzV5+ey9WL1cdh+mUhNkcCfKFLCdslpR+AQWEqWflwIsR5+1tKZN5wrexE/c43j8TqKhNglrKUudcZNkDKPh4XYOq/Fw85Om0lKQunWjmy+4NQEHUBiDk+/9jQUNPJlm0Q0VZ1ipR0HnYei9SanOEsgPUygy62CHC5hfFRmHd7EEjPeF2ek3t93SMO3nLV9cpho9PJAmlwWki9CvCzs2zMESt8ozeEl3+WWiVi+zl44QvSoqInR75e92rwG5r6G1dcjLGrmrIfMJUCXzHJd48KbQNS/2LCHyhtJHwFRPuOwKn2NSCF69JQdrf+U=

--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
 
 # SFR HathiTrust Data Parser
 
-[![Build Status](https://travis-ci.com/NYPL/sfr-hathitrust-reader.svg?branch=development)](https://travis-ci.com/NYPL/sfr-hathitrust-reader)
-![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/nypl/sfr-hathitrust-reader.svg)
+[![Build Status](https://travis-ci.com/NYPL/sfr-hathitrust-reader.svg?branch=development)](https://travis-ci.com/NYPL/sfr-hathitrust-reader) ![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/nypl/sfr-hathitrust-reader.svg)
 
 A function for parsing HathiTrust item records into a SFR-compliant data model. This reads data from spreadsheets made available through the [Hathifiles Page](https://www.hathitrust.org/hathifiles). Each file contains the previous days updates, which are put into the SFR data ingest Kinesis stream, for processing into the database and search index.
-
-## Version
-
-v0.2.1
 
 ## Requirements
 
@@ -18,8 +13,11 @@ Python 3.6+ (written with Python 3.7)
 
 - coverage
 - flake8
+- lxml
 - python-lambda
 - pyyaml
+- requests
+- requests_oauthlib
 
 ## Note
 
@@ -27,7 +25,15 @@ This function is based on the [Python Lambda Boilerplate](https://github.com/NYP
 
 ## Environment Variables
 
-- LOG_LEVEL
+- LOG_LEVEL: Valid values `debug/info/warning/error` (Default: info)
+- OUTPUT_STREAM: Name of the AWS Kinesis stream to write records to
+- OUTPUT_SHARD: Shard of the stream to write records to. For a single shard this is irrelevant
+- HATHI_DATAFILES: URL of HathiTrust page where TSV files can be found. Currently this is: [https://www.hathitrust.org/hathifiles](https://www.hathitrust.org/hathifiles)
+- HATHI_BASE_API: Root API for the HathiTrust Data API. Currently this is: [https://babel.hathitrust.org/cgi/htd](https://babel.hathitrust.org/cgi/htd)
+- HATHI_CLIENT_KEY: Client key for the HathiTrust API
+- HATHI_CLIENT_SECRET: Secret key for the HathiTrust API
+
+NOTE: Credentials for the HathiTrust API can be obtained [here](https://babel.hathitrust.org/cgi/kgs/request) and are generally necessary for all requests to the HathiTrust Data and Content APIs
 
 ## Event Triggers
 
@@ -48,9 +54,14 @@ Tests can be run via the `make test` and linting through `make lint` command and
 
 To deploy the function to a Lambda in you AWS environment run `make deploy ENV=[environment]` where environment designates the desired YAML file you'd like to deploy with.
 
+### Deployment
+
+This function is integrated with travisCI for an automated CI/CD pipeline. The function will be redeployed when a feature branch is merged from a PR
 
 ## A Note on Data
+
 Several transformations are applied to the HathiTrust data as it is received in order to best conform it to match the SFR data model.
+
 1. The `htid` that uniquely identifies each item can be, and is, used to create URLs at which the item itself (a PDF file) can be viewed and downloaded
 2. HathiTrust data contains a robust set of rights data, this is combined into a single class in the SFR data model and associated with both the `instance` and `item` that are created from the Hathi item.
 3. In the TSV format accessed here, several metadata fields are collapsed into single columns. This data exists separately in MARC files accessible via the HathiTrust API. If this data needs to be accessed separately, an additional step calling this API will need to be added to this function.
@@ -58,6 +69,7 @@ Several transformations are applied to the HathiTrust data as it is received in 
 5. The data in the `description` column of the TSV file is treated as volume identifiers. This is useful for distinguishing between different volumes of a periodical and is used in the database manager function for this purpose.
 
 ## TODO
+
 - Improve/verify institution code translations for all fields where used
 - Improve parsing of lifespan dates and other fields from author column
 - Improve publication place/year parsing from publication info column

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -6,3 +6,7 @@ environment_variables:
     OUTPUT_SHARD: '0'
 
     HATHI_DATAFILES: 'https://www.hathitrust.org/filebrowser/download/244651'
+
+    HATHI_BASE_API: https://babel.hathitrust.org/cgi/htd
+    HATHI_CLIENT_KEY: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQHa2gKvc2QKcOep+xbrcMAYAAAAaDBmBgkqhkiG9w0BBwagWTBXAgEAMFIGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM52egtZLslPmTvfTqAgEQgCW65p0pxAxWg5yrZCQp6auwHcUCXE7RZM60K0nwPJgkRwQofJu9
+    HATHI_CLIENT_SECRET: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQF8JJCoMShqcCiHjGeB+DWUAAAAejB4BgkqhkiG9w0BBwagazBpAgEAMGQGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMqG5epEn/klByQxx6AgEQgDfG7fU9bm1IqVCnVmlnGr21KfFTB/3y106k4LgmrjYvNsM3LenY0mJKnq4/53Iu/2kOClWGD7Ew

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -6,3 +6,7 @@ environment_variables:
     OUTPUT_SHARD: '0'
 
     HATHI_DATAFILES: 'https://www.hathitrust.org/filebrowser/download/244651'
+
+    HATHI_BASE_API: https://babel.hathitrust.org/cgi/htd
+    HATHI_CLIENT_KEY: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQHa2gKvc2QKcOep+xbrcMAYAAAAaDBmBgkqhkiG9w0BBwagWTBXAgEAMFIGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM52egtZLslPmTvfTqAgEQgCW65p0pxAxWg5yrZCQp6auwHcUCXE7RZM60K0nwPJgkRwQofJu9
+    HATHI_CLIENT_SECRET: AQICAHg44Tmwi+nLR/0IeFODcEqu2nSlqdDZMsDWalEb1O+LSQF8JJCoMShqcCiHjGeB+DWUAAAAejB4BgkqhkiG9w0BBwagazBpAgEAMGQGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMqG5epEn/klByQxx6AgEQgDfG7fU9bm1IqVCnVmlnGr21KfFTB/3y106k4LgmrjYvNsM3LenY0mJKnq4/53Iu/2kOClWGD7Ew

--- a/helpers/configHelpers.py
+++ b/helpers/configHelpers.py
@@ -1,3 +1,8 @@
+from base64 import b64decode
+from binascii import Error as base64Error
+import boto3
+from botocore.exceptions import ClientError
+import os
 import yaml
 
 from helpers.logHelpers import createLog
@@ -34,3 +39,23 @@ def loadEnvFile(runType, fileString):
     if envDict is None:
         envDict = {}
     return envDict, fileLines
+
+
+def decryptEnvVar(envVar):
+    """This helper method takes a KMS encoded environment variable and decrypts
+    it into a usable value. Sensitive variables should be so encoded so that
+    they can be stored in git and used in a CI/CD environment.
+    Arguments:
+        envVar {string} -- a string, either plaintext or a base64, encrypted
+        value
+    """
+    encrypted = os.environ.get(envVar, None)
+
+    try:
+        decoded = b64decode(encrypted)
+        # If region is not set, assume us-east-1
+        regionName = os.environ.get('AWS_REGION', 'us-east-1')
+        return boto3.client('kms', region_name=regionName)\
+            .decrypt(CiphertextBlob=decoded)['Plaintext'].decode('utf-8')
+    except (ClientError, base64Error, TypeError):
+        return encrypted

--- a/lib/countryParser.py
+++ b/lib/countryParser.py
@@ -30,7 +30,13 @@ def loadCountryCodes():
     with countryXML as countryXML:
         countryTree = etree.parse(countryXML)
         codeList = countryTree.getroot()
-        
+
         logger.info('Retrieving country names from lib/marc_countries.xml')
         ns = '{info:lc/xmlns/codelist-v1}'
-        return dict([(c.find('{}code'.format(ns)).text, c.find('{}name'.format(ns)).text) for c in codeList.findall('.//{}country'.format(ns))])
+        return dict([
+            (
+                c.find('{}code'.format(ns)).text,
+                c.find('{}name'.format(ns)).text
+            )
+            for c in codeList.findall('.//{}country'.format(ns))
+        ])

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -92,6 +92,7 @@ class InstanceRecord(DataObject):
         self.formats = []
         self.measurements = []
         self.dates = []
+        self.links = []
         self.rights = None
 
     def __repr__(self):

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -67,8 +67,16 @@ class WorkRecord(DataObject):
         self.rights = None
 
     def __repr__(self):
-        dispTitle = self.title[:50] + '...' if self.title is not None and len(self.title) > 50 else self.title
-        primaryID = None if self.primary_identifier is None else self.primary_identifier.identifier
+        if self.title is not None and len(self.title) > 50:
+            dispTitle = self.title[:50] + '...'
+        else:
+            dispTitle = self.title
+
+        if self.primary_identifier is None:
+            primaryID = None
+        else:
+            self.primary_identifier.identifier
+
         return '<Work(title={}, primary_id={})>'.format(
             dispTitle,
             primaryID
@@ -96,7 +104,10 @@ class InstanceRecord(DataObject):
         self.rights = None
 
     def __repr__(self):
-        dispTitle = self.title[:50] + '...' if self.title is not None and len(self.title) > 50 else self.title
+        if self.title is not None and len(self.title) > 50:
+            dispTitle = self.title[:50] + '...'
+        else:
+            dispTitle = self.title
         return '<Instance(title={}, pub_place={})>'.format(
             dispTitle,
             self.pub_place
@@ -104,7 +115,8 @@ class InstanceRecord(DataObject):
 
 
 class Format(DataObject):
-    def __init__(self, source=None, contentType=None, link=None, modified=None):
+    def __init__(self,
+                 source=None, contentType=None, link=None, modified=None):
         super()
         self.source = source
         self.content_type = contentType
@@ -202,7 +214,9 @@ class Subject(DataObject):
 
 
 class Measurement(DataObject):
-    def __init__(self, quantity=None, value=None, weight=None, takenAt=None, sourceID=None):
+    def __init__(self,
+                 quantity=None, value=None, weight=None,
+                 takenAt=None, sourceID=None):
         super()
         self.quantity = quantity
         self.value = value
@@ -218,7 +232,10 @@ class Measurement(DataObject):
 
     @staticmethod
     def getValueForMeasurement(measurementList, quantity):
-        retMeasurement = list(filter(lambda x: x['quantity'] == quantity, measurementList))
+        retMeasurement = list(filter(
+            lambda x: x['quantity'] == quantity,
+            measurementList
+        ))
         return retMeasurement[0]['value']
 
 

--- a/lib/hathiCover.py
+++ b/lib/hathiCover.py
@@ -6,9 +6,16 @@ from helpers.configHelpers import decryptEnvVar
 
 
 class HathiCover():
+    """Manager class for finding a cover image for HathiTrust images. This is
+    done by parsing a METS object obtained through the Hathi API, extracting
+    the first 25 pages and scoring them based on relevancy as a cover. The
+    URI to the most relevant page image is ultimately returned.
+    """
     HATHI_BASE_API = os.environ.get('HATHI_BASE_API', None)
     HATHI_CLIENT_KEY = decryptEnvVar(os.environ.get('HATHI_CLIENT_KEY', None))
-    HATHI_CLIENT_SECRET = decryptEnvVar(os.environ.get('HATHI_CLIENT_SECRET', None))
+    HATHI_CLIENT_SECRET = decryptEnvVar(
+        os.environ.get('HATHI_CLIENT_SECRET', None)
+    )
 
     def __init__(self, htid):
         self.htid = htid
@@ -16,6 +23,13 @@ class HathiCover():
 
     @classmethod
     def generateOAuth(cls):
+        """Helper method that generates an OAuth1 block that authenticates
+        requests against the HathiTrust Data API. Due to the structure of the
+        API this is formatted as part of the query string.
+
+        Returns:
+            [object] -- An OAuth1 authentication block
+        """
         return OAuth1(
             cls.HATHI_CLIENT_KEY,
             client_secret=cls.HATHI_CLIENT_SECRET,
@@ -23,6 +37,11 @@ class HathiCover():
         )
 
     def getPageFromMETS(self):
+        """Query method for the best page URI from the record's METS file
+
+        Returns:
+            [uri] -- URI to the page to be used as a cover image
+        """
         structURL = '{}/structure/{}?format=json&v=2'.format(
             self.HATHI_BASE_API,
             self.htid
@@ -35,6 +54,17 @@ class HathiCover():
         return None
 
     def parseMETS(self, metsJson):
+        """Parser that handles the METS file, parsing the first 25 pages into
+        HathiPage objects that contain a score and position. Once parsed it
+        sets the "imagePage" as the page that contains the most plausibly
+        relevant cover.
+
+        Arguments:
+            metsJson {object} -- METS object extracted from the JSON response
+
+        Returns:
+            [uri] -- URI to the page to be used as a cover image
+        """
         structMap = metsJson['METS:structMap']
 
         self.pages = [
@@ -47,6 +77,12 @@ class HathiCover():
         return self.getPageURL()
 
     def getPageURL(self):
+        """Extracts a resolvable URI from the page selected as a cover image.
+        This URI can be used to create a local copy of the cover.
+
+        Returns:
+            [uri] -- The created URI of the cover page
+        """
         return '{}/volume/pageimage/{}/{}?format=jpeg&v=2'.format(
             self.HATHI_BASE_API,
             self.htid,
@@ -55,6 +91,14 @@ class HathiCover():
 
 
 class HathiPage():
+    """A representation of a single page in a HathiTrust record. This contains
+    some basic description of the page as well as some metadata that we derive
+    from Hathi's description to rank it in terms of its suitability as a cover
+    image.
+    """
+
+    # These are the "flags" that denote a potential cover page
+    # They are drawn from a larger set of flags that can be attached to a page
     PAGE_FEATURES = set(
         ['FRONT_COVER', 'TITLE', 'IMAGE_ON_PAGE', 'TABLE_OF_CONTENTS']
     )
@@ -66,11 +110,34 @@ class HathiPage():
         self.score = self.setScore()
 
     def getPageNo(self):
+        """Extracts the current page number (from the front cover, not number
+        on the page) from the METS description of the page
+
+        Returns:
+            [integer] -- The current page number
+        """
         return self.pageData.get('ORDER', 0)
 
     def parseFlags(self):
+        """Extracts the flags (in METS these are grouped under "LABEL") that
+        can be used to determine the contents of a page. These are parsed from
+        a comma-delimited string into a set.
+
+        Returns:
+            [set] -- Unique set of flags assigned to the page
+        """
         flagStr = self.pageData.get('LABEL', '')
         return set(flagStr.split(', '))
 
     def setScore(self):
+        """This takes the union of the flags denoted as potentially interesting
+        in the class variable above and the current flags set on the page. The
+        total count of the resulting set is the "score" for the page,
+        essentially how many potentially interesting elements exist on it. This
+        allows the HathiCover class to determine the best possible to cover
+        to display.
+
+        Returns:
+            [integer] -- The score as derived from the union of the flags set
+        """
         return len(list(self.flags & self.PAGE_FEATURES))

--- a/lib/hathiCover.py
+++ b/lib/hathiCover.py
@@ -1,0 +1,76 @@
+import os
+import requests
+from requests_oauthlib import OAuth1
+
+from helpers.configHelpers import decryptEnvVar
+
+
+class HathiCover():
+    HATHI_BASE_API = os.environ.get('HATHI_BASE_API', None)
+    HATHI_CLIENT_KEY = decryptEnvVar(os.environ.get('HATHI_CLIENT_KEY', None))
+    HATHI_CLIENT_SECRET = decryptEnvVar(os.environ.get('HATHI_CLIENT_SECRET', None))
+
+    def __init__(self, htid):
+        self.htid = htid
+        self.oauth = self.generateOAuth()
+
+    @classmethod
+    def generateOAuth(cls):
+        return OAuth1(
+            cls.HATHI_CLIENT_KEY,
+            client_secret=cls.HATHI_CLIENT_SECRET,
+            signature_type='query'
+        )
+
+    def getPageFromMETS(self):
+        structURL = '{}/structure/{}?format=json&v=2'.format(
+            self.HATHI_BASE_API,
+            self.htid
+        )
+        structResp = requests.get(structURL, auth=self.oauth)
+
+        if structResp.status_code == 200:
+            return self.parseMETS(structResp.json())
+
+        return None
+
+    def parseMETS(self, metsJson):
+        structMap = metsJson['METS:structMap']
+
+        self.pages = [
+            HathiPage(page)
+            for page in structMap['METS:div']['METS:div'][:25]
+        ]
+
+        self.pages.sort(key=lambda x: x.score, reverse=True)
+        self.imagePage = self.pages[0]
+        return self.getPageURL()
+
+    def getPageURL(self):
+        return '{}/volume/pageimage/{}/{}?format=jpeg&v=2'.format(
+            self.HATHI_BASE_API,
+            self.htid,
+            self.imagePage.page
+        )
+
+
+class HathiPage():
+    PAGE_FEATURES = set(
+        ['FRONT_COVER', 'TITLE', 'IMAGE_ON_PAGE', 'TABLE_OF_CONTENTS']
+    )
+
+    def __init__(self, pageData):
+        self.pageData = pageData
+        self.page = self.getPageNo()
+        self.flags = self.parseFlags()
+        self.score = self.setScore()
+
+    def getPageNo(self):
+        return self.pageData.get('ORDER', 0)
+
+    def parseFlags(self):
+        flagStr = self.pageData.get('LABEL', '')
+        return set(flagStr.split(', '))
+
+    def setScore(self):
+        return len(list(self.flags & self.PAGE_FEATURES))

--- a/lib/hathiCover.py
+++ b/lib/hathiCover.py
@@ -12,9 +12,9 @@ class HathiCover():
     URI to the most relevant page image is ultimately returned.
     """
     HATHI_BASE_API = os.environ.get('HATHI_BASE_API', None)
-    HATHI_CLIENT_KEY = decryptEnvVar(os.environ.get('HATHI_CLIENT_KEY', None))
+    HATHI_CLIENT_KEY = decryptEnvVar(os.environ.get('HATHI_CLIENT_KEY', ''))
     HATHI_CLIENT_SECRET = decryptEnvVar(
-        os.environ.get('HATHI_CLIENT_SECRET', None)
+        os.environ.get('HATHI_CLIENT_SECRET', '')
     )
 
     def __init__(self, htid):

--- a/lib/hathiRecord.py
+++ b/lib/hathiRecord.py
@@ -295,13 +295,17 @@ class HathiRecord():
         # We need a fallback modified date if none is provided
         if self.modified is None:
             self.modified = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-            logger.debug('Assigning generated timestamp of {} to new record'.format(self.modified))
+            logger.debug(
+                'Assigning generated timestamp of {} to new record'.format(
+                    self.modified
+                )
+            )
         elif type(self.modified) is datetime:
             self.modified = self.modified.strftime('%Y-%m-%d %H:%M:%S')
 
     def __repr__(self):
         return '<Hathi(title={})>'.format(self.work.title)
-    
+
     def buildDataModel(self, countryCodes):
         logger.debug('Generating work record for bib record {}'.format(
             self.ingest['bib_key']
@@ -311,9 +315,11 @@ class HathiRecord():
         # been improperly formatted (generally fields out of order/misplaced)
         # Raise a warning but continue if this is found to be true
         if self.ingest['rights_statement'] not in HathiRecord.rightsReasons:
-            raise DataError('{} is malformed (columns missing or incorrect'.format(
-                self.ingest['htid']
-            ))
+            raise DataError(
+                '{} is malformed (columns missing or incorrect'.format(
+                    self.ingest['htid']
+                )
+            )
 
         self.buildWork()
 
@@ -326,7 +332,7 @@ class HathiRecord():
             self.ingest['htid']
         ))
         self.buildItem()
-        
+
         logger.debug('Generate a rights object for the associated rights statement {}'.format(
             self.ingest['rights']
         ))
@@ -338,7 +344,7 @@ class HathiRecord():
     def buildWork(self):
         """Construct the SFR Work object from the Hathi data"""
         self.work.title = self.ingest['title']
-        
+
         logger.info('Creating work record for {}'.format(self.work.title))
         # The primary identifier for this work is a HathiTrust bib reference
         self.work.primary_identifier = Identifier(
@@ -370,7 +376,9 @@ class HathiRecord():
         try:
             self.parseAuthor(self.ingest['author'])
         except KeyError:
-            logger.warning('No author associated with record {}'.format(self.work))
+            logger.warning('No author associated with record {}'.format(
+                self.work
+            ))
 
     def buildInstance(self, countryCodes):
         """Constrict an instance record from the Hathi data provided. As
@@ -437,10 +445,15 @@ class HathiRecord():
         logger.debug('Setting htid {} for item'.format(self.ingest['htid']))
         self.parseIdentifiers(self.item, 'hathi', 'htid')
 
-        logger.debug('Storing direct and download links based on htid {}'.format(self.ingest['htid']))
+        logger.debug(
+            'Storing direct and download links based on htid {}'.format(
+                self.ingest['htid']
+            ))
         # The link to the external HathiTrust page
         self.item.addClassItem('links', Link, **{
-            'url': 'https://babel.hathitrust.org/cgi/pt?id={}'.format(self.ingest['htid']),
+            'url': 'https://babel.hathitrust.org/cgi/pt?id={}'.format(
+                self.ingest['htid']
+            ),
             'media_type': 'text/html',
             'flags': {
                 'local': False,
@@ -462,7 +475,9 @@ class HathiRecord():
             }
         })
 
-        logger.debug('Storing repository {} as agent'.format(self.ingest['source']))
+        logger.debug('Storing repository {} as agent'.format(
+            self.ingest['source']
+        ))
         self.item.addClassItem('agents', Agent, **{
             'name': self.ingest['source'],
             'roles': ['repository']
@@ -486,7 +501,6 @@ class HathiRecord():
 
         # Add item to parent instance
         self.instance.formats.append(self.item)
-
 
     def createRights(self):
         """HathiTrust contains a strong set of rights data per item, including
@@ -580,7 +594,10 @@ class HathiRecord():
                 dateType = 'death_date'
                 datePrefix = re.search(r' b(?: |\.)', authorStr)
                 if datePrefix is not None:
-                    authorRec.name = re.sub(r' b(?: |\.|$)', '', authorName).strip(' ,.')
+                    authorRec.name = re.sub(
+                        r' b(?: |\.|$)', '',
+                        authorName
+                    ).strip(' ,.')
                     logger.debug('Detected single birth_date (living author)')
                     dateType = 'birth_date'
 

--- a/lib/hathiRecord.py
+++ b/lib/hathiRecord.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime
 
+from lib.hathiCover import HathiCover
 from lib.dataModel import (
     WorkRecord,
     Identifier,
@@ -370,7 +371,6 @@ class HathiRecord():
             self.parseAuthor(self.ingest['author'])
         except KeyError:
             logger.warning('No author associated with record {}'.format(self.work))
-            
 
     def buildInstance(self, countryCodes):
         """Constrict an instance record from the Hathi data provided. As
@@ -401,6 +401,19 @@ class HathiRecord():
         logger.debug('Setting copyright date to {}'.format(
             self.ingest['copyright_date']
         ))
+
+        coverFetch = HathiCover(self.ingest['htid'])
+        pageURL = coverFetch.getPageFromMETS()
+        if pageURL is not None:
+            logger.debug('Add cover image {} to instance'.format(pageURL))
+            self.instance.addClassItem('links', Link, **{
+                'url': pageURL,
+                'media_type': 'image/jpeg',
+                'flags': {
+                    'cover': True,
+                    'temporary': True,
+                }
+            })
 
         self.parsePubInfo(self.ingest['publisher_pub_date'])
 

--- a/lib/kinesisWrite.py
+++ b/lib/kinesisWrite.py
@@ -32,6 +32,6 @@ class KinesisOutput():
                 Data=kinesisStream,
                 PartitionKey=os.environ['OUTPUT_SHARD']
             )
-        except:
+        except:  # noqa: E722
             logger.error('Kinesis Write error!')
             raise KinesisError('Failed to write result to output stream!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml
 python-lambda
 pyyaml
 requests
+requests_oauthlib

--- a/tests/test_countryParse.py
+++ b/tests/test_countryParse.py
@@ -9,7 +9,7 @@ class TestCountry(unittest.TestCase):
 
     def test_country_load(self):
         testData = (
-            '<codelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="info:lc/xmlns/codelist-v1" version="1.0" xsi:schemaLocation="info:lc/xmlns/codelist-v1 http://www.loc.gov/standards/codelists/codelist.xsd">'
+            '<codelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="info:lc/xmlns/codelist-v1" version="1.0" xsi:schemaLocation="info:lc/xmlns/codelist-v1 http://www.loc.gov/standards/codelists/codelist.xsd">'  # noqa: E501
             '<codelistId>marccountry</codelistId>'
             '<title>MARC Code List for Countries</title>'
             '<countries>'
@@ -23,8 +23,8 @@ class TestCountry(unittest.TestCase):
             '</codelist>'
         )
         mOpen = mock_open(read_data=testData)
-        mOpen.return_value.__iter__ = lambda self: self
-        mOpen.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        mOpen.return_value.__iter__ = lambda s: s
+        mOpen.return_value.__next__ = lambda s: next(iter(s.readline, ''))
         with patch('lib.countryParser.open', mOpen, create=True):
             countryList = loadCountryCodes()
             self.assertEqual(countryList['af'], 'Afghanistan')

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,7 +1,15 @@
 import unittest
 from unittest.mock import patch, mock_open, MagicMock, call
 
-from service import handler, loadLocalCSV, fetchHathiCSV, fileParser, rowParser, processChunk, generateChunks
+from service import (
+    handler,
+    loadLocalCSV,
+    fetchHathiCSV,
+    fileParser,
+    rowParser,
+    processChunk,
+    generateChunks
+)
 from helpers.errorHelpers import ProcessingError, DataError, KinesisError
 
 
@@ -45,17 +53,19 @@ class TestHandler(unittest.TestCase):
 
     def test_local_csv_success(self):
         mOpen = mock_open(read_data='id1\tr1.2\tpd\nid2\tr2.2\tpd\n')
-        mOpen.return_value.__iter__ = lambda self: self
-        mOpen.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        mOpen.return_value.__iter__ = lambda s: s
+        mOpen.return_value.__next__ = lambda s: next(iter(s.readline, ''))
         with patch('service.open', mOpen, create=True) as mCSV:
             rows = loadLocalCSV('localFile')
             mCSV.assert_called_once_with('localFile', newline='')
             self.assertEqual(rows[0][0], 'id1')
 
     def test_local_csv_header(self):
-        mOpen = mock_open(read_data='htid\tt1\tt2\nid1\tr1.2\tpd\nid2\tr2.2\tpd\n')
-        mOpen.return_value.__iter__ = lambda self: self
-        mOpen.return_value.__next__ = lambda self: next(iter(self.readline, ''))
+        mOpen = mock_open(
+            read_data='htid\tt1\tt2\nid1\tr1.2\tpd\nid2\tr2.2\tpd\n'
+        )
+        mOpen.return_value.__iter__ = lambda s: s
+        mOpen.return_value.__next__ = lambda s: next(iter(s.readline, ''))
         with patch('service.open', mOpen, create=True) as mCSV:
             rows = loadLocalCSV('localFile')
             mCSV.assert_called_once_with('localFile', newline='')
@@ -89,8 +99,6 @@ class TestHandler(unittest.TestCase):
                     call('hathitrust.org/test/file.txt.gz')
                 ])
                 mock_gzip.assert_called_once()
-                
-
 
     @patch('service.loadCountryCodes', return_value={})
     @patch('service.Process')
@@ -124,7 +132,7 @@ class TestHandler(unittest.TestCase):
             mock_row.assert_any_call(['row3'], ['htid'], {})
             mock_row.assert_any_call(['row2'], ['htid'], {})
             mock_row.assert_any_call(['row1'], ['htid'], {})
-    
+
     def test_yield_chunks(self):
         testRows = ['row1', 'row2', 'row3', 'row4', 'row5', 'row6']
         for chunk in generateChunks(testRows, 2):

--- a/tests/test_hathiCover.py
+++ b/tests/test_hathiCover.py
@@ -1,0 +1,96 @@
+from random import random
+import unittest
+from unittest.mock import DEFAULT, MagicMock, patch
+
+from lib.hathiCover import HathiCover, HathiPage
+
+
+class TestHathiCover(unittest.TestCase):
+    @patch.object(HathiCover, 'generateOAuth', return_value='oauthHelper')
+    def test_HathiCover_init(self, mockOAuth):
+        testHathi = HathiCover('test.1')
+        self.assertEqual(testHathi.htid, 'test.1')
+        self.assertEqual(testHathi.oauth, 'oauthHelper')
+
+    @patch('lib.hathiCover.OAuth1', return_value='oauthHelper')
+    def test_cover_generate_oauth(self, mockOauth):
+        testAuth = HathiCover.generateOAuth()
+        mockOauth.assert_called_once_with(
+            None,
+            client_secret=None,
+            signature_type='query'
+        )
+        self.assertEqual(testAuth, 'oauthHelper')
+
+    @patch('lib.hathiCover.requests')
+    @patch.multiple(HathiCover, generateOAuth=DEFAULT, parseMETS=DEFAULT)
+    def test_HathiCover_getPageFromMETS(self, mockReq, generateOAuth, parseMETS):
+        generateOAuth.return_value = 'oauthHelper'
+        testHathi = HathiCover('test.1')
+
+        mockResp = MagicMock()
+        mockResp.status_code = 200
+        mockResp.json = MagicMock()
+        mockReq.get.return_value = mockResp
+
+        parseMETS.return_value = 'test_page_url'
+        testURL = testHathi.getPageFromMETS()
+        mockReq.get.assert_called_once_with(
+            'None/structure/test.1?format=json&v=2', auth='oauthHelper'
+        )
+        parseMETS.assert_called_once()
+        self.assertEqual(testURL, 'test_page_url')
+
+    @patch.object(HathiCover, 'generateOAuth', return_value='oauthHelper')
+    @patch('lib.hathiCover.requests')
+    def test_HathiCover_getPageFromMETS_error(self, mockReq, mockOAuth):
+        testHathi = HathiCover('test.1')
+
+        mockResp = MagicMock()
+        mockResp.status_code = 500
+        mockResp.json = MagicMock()
+        mockReq.get.return_value = mockResp
+
+        testURL = testHathi.getPageFromMETS()
+        mockReq.get.assert_called_once_with(
+            'None/structure/test.1?format=json&v=2', auth='oauthHelper'
+        )
+        self.assertEqual(testURL, None)
+
+    @patch('lib.hathiCover.OAuth1', return_value='oauthHelper')
+    @patch.object(HathiCover, 'getPageURL', return_value='test_page')
+    @patch.multiple(HathiPage, getPageNo=DEFAULT, parseFlags=DEFAULT, setScore=DEFAULT)
+    def test_cover_parseMETS(self, mockPage, mockOauth, getPageNo, parseFlags, setScore):
+        def createTestStruct():
+            pages = []
+            for i in range(25):
+                pages.append({'page': i, 'score': random()})
+            sortedPages = sorted(pages, key=lambda x: x['score'], reverse=True)
+            testMETS = {
+                'METS:structMap': {
+                    'METS:div': {
+                        'METS:div': pages
+                    }
+                }
+            }
+            return testMETS, sortedPages[0]
+
+        testMETS, topPage = createTestStruct()
+        setScore.side_effect = [
+            p['score']
+            for p in testMETS['METS:structMap']['METS:div']['METS:div']
+        ]
+        testHathi = HathiCover('test.1')
+        testOutput = testHathi.parseMETS(testMETS)
+        mockPage.assert_called_once()
+        self.assertEqual(testHathi.imagePage.score, topPage['score'])
+        self.assertEqual(testOutput, 'test_page')
+
+    @patch.object(HathiCover, 'generateOAuth', return_value='oauthHelper')
+    def test_HathiCover_getPageURL(self, mockOAuth):
+        testHathi = HathiCover('test.1')
+        mockPage = MagicMock()
+        mockPage.page = 1
+        testHathi.imagePage = mockPage
+        testURL = testHathi.getPageURL()
+        self.assertEqual(testURL, 'None/volume/pageimage/test.1/1?format=jpeg&v=2')

--- a/tests/test_hathiCover.py
+++ b/tests/test_hathiCover.py
@@ -24,7 +24,8 @@ class TestHathiCover(unittest.TestCase):
 
     @patch('lib.hathiCover.requests')
     @patch.multiple(HathiCover, generateOAuth=DEFAULT, parseMETS=DEFAULT)
-    def test_HathiCover_getPageFromMETS(self, mockReq, generateOAuth, parseMETS):
+    def test_HathiCover_getPageFromMETS(self,
+                                        mockReq, generateOAuth, parseMETS):
         generateOAuth.return_value = 'oauthHelper'
         testHathi = HathiCover('test.1')
 
@@ -59,8 +60,15 @@ class TestHathiCover(unittest.TestCase):
 
     @patch('lib.hathiCover.OAuth1', return_value='oauthHelper')
     @patch.object(HathiCover, 'getPageURL', return_value='test_page')
-    @patch.multiple(HathiPage, getPageNo=DEFAULT, parseFlags=DEFAULT, setScore=DEFAULT)
-    def test_cover_parseMETS(self, mockPage, mockOauth, getPageNo, parseFlags, setScore):
+    @patch.multiple(
+        HathiPage,
+        getPageNo=DEFAULT,
+        parseFlags=DEFAULT,
+        setScore=DEFAULT
+    )
+    def test_cover_parseMETS(self,
+                             mockPage, mockOauth, getPageNo, parseFlags,
+                             setScore):
         def createTestStruct():
             pages = []
             for i in range(25):
@@ -93,4 +101,7 @@ class TestHathiCover(unittest.TestCase):
         mockPage.page = 1
         testHathi.imagePage = mockPage
         testURL = testHathi.getPageURL()
-        self.assertEqual(testURL, 'None/volume/pageimage/test.1/1?format=jpeg&v=2')
+        self.assertEqual(
+            testURL,
+            'None/volume/pageimage/test.1/1?format=jpeg&v=2'
+        )

--- a/tests/test_hathiPage.py
+++ b/tests/test_hathiPage.py
@@ -5,7 +5,12 @@ from lib.hathiCover import HathiPage
 
 
 class TestHathiPage(unittest.TestCase):
-    @patch.multiple(HathiPage, getPageNo=DEFAULT, parseFlags=DEFAULT, setScore=DEFAULT)
+    @patch.multiple(
+        HathiPage,
+        getPageNo=DEFAULT,
+        parseFlags=DEFAULT,
+        setScore=DEFAULT
+    )
     def test_HathiPage_init(self, getPageNo, parseFlags, setScore):
         getPageNo.return_value = 1
         parseFlags.return_value = {'testing': True}
@@ -16,7 +21,7 @@ class TestHathiPage(unittest.TestCase):
         self.assertEqual(testPage.page, 1)
         self.assertTrue(testPage.flags['testing'])
         self.assertEqual(testPage.score, 10)
-    
+
     @patch.multiple(HathiPage, parseFlags=DEFAULT, setScore=DEFAULT)
     def test_HathiPage_getPageNo(self, parseFlags, setScore):
         testPage = HathiPage({'ORDER': 3})
@@ -25,7 +30,10 @@ class TestHathiPage(unittest.TestCase):
     @patch.multiple(HathiPage, getPageNo=DEFAULT, setScore=DEFAULT)
     def test_HathiPage_parseFlags(self, getPageNo, setScore):
         testPage = HathiPage({'LABEL': 'TITLE, IMAGE_ON_PAGE, TEST'})
-        self.assertEqual(testPage.flags, set(['TITLE', 'IMAGE_ON_PAGE', 'TEST']))
+        self.assertEqual(
+            testPage.flags,
+            set(['TITLE', 'IMAGE_ON_PAGE', 'TEST'])
+        )
 
     @patch.multiple(HathiPage, getPageNo=DEFAULT, parseFlags=DEFAULT)
     def test_HathiPage_setScore(self, getPageNo, parseFlags):

--- a/tests/test_hathiPage.py
+++ b/tests/test_hathiPage.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch, DEFAULT
+
+from lib.hathiCover import HathiPage
+
+
+class TestHathiPage(unittest.TestCase):
+    @patch.multiple(HathiPage, getPageNo=DEFAULT, parseFlags=DEFAULT, setScore=DEFAULT)
+    def test_HathiPage_init(self, getPageNo, parseFlags, setScore):
+        getPageNo.return_value = 1
+        parseFlags.return_value = {'testing': True}
+        setScore.return_value = 10
+
+        testPage = HathiPage('data')
+        self.assertEqual(testPage.pageData, 'data')
+        self.assertEqual(testPage.page, 1)
+        self.assertTrue(testPage.flags['testing'])
+        self.assertEqual(testPage.score, 10)
+    
+    @patch.multiple(HathiPage, parseFlags=DEFAULT, setScore=DEFAULT)
+    def test_HathiPage_getPageNo(self, parseFlags, setScore):
+        testPage = HathiPage({'ORDER': 3})
+        self.assertEqual(testPage.page, 3)
+
+    @patch.multiple(HathiPage, getPageNo=DEFAULT, setScore=DEFAULT)
+    def test_HathiPage_parseFlags(self, getPageNo, setScore):
+        testPage = HathiPage({'LABEL': 'TITLE, IMAGE_ON_PAGE, TEST'})
+        self.assertEqual(testPage.flags, set(['TITLE', 'IMAGE_ON_PAGE', 'TEST']))
+
+    @patch.multiple(HathiPage, getPageNo=DEFAULT, parseFlags=DEFAULT)
+    def test_HathiPage_setScore(self, getPageNo, parseFlags):
+        parseFlags.return_value = set(['TITLE', 'FRONT_COVER'])
+        testPage = HathiPage('data')
+        self.assertEqual(testPage.score, 2)


### PR DESCRIPTION
This implements cover fetching for HathiTrust records, retrieving them through the HathiTrust Data API. This doesn't directly expose the covers, but instead a METS file for each record which can be parsed to find the most relevant cover record. This URL can then be returned to the function, where it can be persisted in the database and from there stored in s3 for a permanent, local file.

This is somewhat complicated by the fact that the METS file does not identify the "cover" image used by HathiTrust, which is not always the actual cover, but can be the title page or other page depending on the state/version of the cover. Frequently this is just a plain cloth binding which is not of interest to users. To replicate this functionality the reader uses `flags` that get set by HathiTrust to pick out the first, most interesting image.

The HathiTrust Data API requires all requests be authenticated, the current credentials for the project are stored in AWS KMS but this should be documented elsewhere for future reference.