### PR TITLE
SFR-703 Catch error raised by cover class

### DIFF
--- a/lib/hathiCover.py
+++ b/lib/hathiCover.py
@@ -59,9 +59,12 @@ class HathiCover():
             self.HATHI_BASE_API,
             self.htid
         )
-        structResp = self.getResponse(structURL)
-        if structResp.status_code == 200:
-            return self.parseMETS(structResp.json())
+        try:
+            structResp = self.getResponse(structURL)
+            if structResp.status_code == 200:
+                return self.parseMETS(structResp.json())
+        except URLFetchError:
+            self.logger('Request for structure file timed out')
 
         return None
 


### PR DESCRIPTION
The cover class threw an `URLFetcchError` when the request timed out, which causes errors with the multiprocessing library. This catches those errors and simply returns `None` if a timeout occurs.