### PR TITLE
SFR-703 performance improvements

### DIFF
--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -147,14 +147,17 @@ class Format(DataObject):
 
 
 class Agent(DataObject):
-    def __init__(self, name=None, role=None, aliases=[], link=None):
+    def __init__(self, name=None, role=None, aliases=None, link=None):
         super()
         self.name = name
         self.sort_name = None
         self.lcnaf = None
         self.viaf = None
         self.biography = None
-        self.aliases = aliases
+        if aliases is None:
+            self.aliases = []
+        else:
+            self.aliases = None
         self.link = link
         self.dates = []
 

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -147,7 +147,7 @@ class Format(DataObject):
 
 
 class Agent(DataObject):
-    def __init__(self, name=None, role=None, aliases=None, link=None):
+    def __init__(self, name=None, role=None, aliases=[], link=None):
         super()
         self.name = name
         self.sort_name = None

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -157,7 +157,7 @@ class Agent(DataObject):
         if aliases is None:
             self.aliases = []
         else:
-            self.aliases = None
+            self.aliases = aliases
         self.link = link
         self.dates = []
 

--- a/lib/hathiCover.py
+++ b/lib/hathiCover.py
@@ -64,7 +64,7 @@ class HathiCover():
             if structResp.status_code == 200:
                 return self.parseMETS(structResp.json())
         except URLFetchError:
-            self.logger('Request for structure file timed out')
+            self.logger.warning('Request for structure file timed out')
 
         return None
 

--- a/lib/hathiRecord.py
+++ b/lib/hathiRecord.py
@@ -452,6 +452,16 @@ class HathiRecord():
         # generated rights information
         self.createRights()
 
+        for agent in self.work.agents:
+            self.getVIAF(agent)
+
+        for instance in self.work.instances:
+            for agent in instance.agents:
+                self.getVIAF(agent)
+            for item in instance.formats:
+                for agent in item.agents:
+                    self.getVIAF(agent)
+
     def buildWork(self):
         """Construct the SFR Work object from the Hathi data"""
         self.work.title = self.ingest['title']
@@ -743,8 +753,6 @@ class HathiRecord():
                 })
         logger.debug('Appending agent record {} to work'.format(authorRec))
 
-        self.getVIAF(authorRec)
-
         self.work.agents.append(authorRec)
 
     def getVIAF(self, agent):
@@ -759,7 +767,8 @@ class HathiRecord():
                 responseJSON.get('viaf', None)
             ))
             if responseJSON['name'] != agent.name:
-                agent.aliases.append(agent.name)
+                if agent.name not in agent.aliases:
+                    agent.aliases.append(agent.name)
                 agent.name = responseJSON.get('name', '')
             agent.viaf = responseJSON.get('viaf', None)
             agent.lcnaf = responseJSON.get('lcnaf', None)

--- a/lib/kinesisWrite.py
+++ b/lib/kinesisWrite.py
@@ -16,7 +16,7 @@ class KinesisOutput():
         pass
 
     @classmethod
-    def putRecord(cls, outputObject, stream):
+    def putRecord(cls, outputObject, stream, partKey):
         """Put an event into the specific Kinesis stream"""
         logger.info('Writing results to Kinesis')
 
@@ -30,7 +30,7 @@ class KinesisOutput():
             cls.KINESIS_CLIENT.put_record(
                 StreamName=stream,
                 Data=kinesisStream,
-                PartitionKey=os.environ['OUTPUT_SHARD']
+                PartitionKey=partKey
             )
         except:  # noqa: E722
             logger.error('Kinesis Write error!')

--- a/service.py
+++ b/service.py
@@ -103,7 +103,7 @@ def handler(event, context):
         traceback.print_exc()
 
     logger.info('Successfully invoked lambda')
-
+    logger.debug('Processed Rows {}'.format(len(output)))
     return output
 
 
@@ -272,7 +272,8 @@ def processChunk(chunk, columns, countryCodes, cConn):
 
     for row in chunk:
         try:
-            cConn.send(rowParser(row, columns, countryCodes))
+            parsedRec = rowParser(row, columns, countryCodes)
+            cConn.send(parsedRec)
         except ProcessingError as err:
             cConn.send(('failure', err.source, err.message))
         except Exception as err:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -16,7 +16,7 @@ from helpers.errorHelpers import ProcessingError, DataError, KinesisError
 class TestHandler(unittest.TestCase):
 
     @patch('service.loadLocalCSV', return_value=['row1', 'row2'])
-    @patch('service.fileParser', return_value=True)
+    @patch('service.fileParser', return_value=[1, 2])
     def test_handler_local(self, mock_parser, mock_load):
         testRec = {
             'source': 'local.file',
@@ -27,10 +27,10 @@ class TestHandler(unittest.TestCase):
         resp = handler(testRec, None)
         mock_load.assert_called_once()
         mock_parser.assert_called_once()
-        self.assertTrue(resp)
+        self.assertEqual(resp, [1, 2])
 
     @patch('service.fetchHathiCSV', return_value=['row1', 'row2'])
-    @patch('service.fileParser', return_value=True)
+    @patch('service.fileParser', return_value=[1, 2])
     def test_handler_scheduled(self, mock_parser, mock_fetch):
         testRec = {
             'source': 'Kinesis',
@@ -40,10 +40,10 @@ class TestHandler(unittest.TestCase):
         resp = handler(testRec, None)
         mock_fetch.assert_called_once()
         mock_parser.assert_called_once()
-        self.assertTrue(resp)
+        self.assertEqual(resp, [1, 2])
 
     @patch('service.fetchHathiCSV', return_value=['row1', 'row2'])
-    @patch('service.fileParser', return_value=True)
+    @patch('service.fileParser', return_value=[])
     def test_handler_empty(self, mock_file, mock_fetch):
         testRec = {
             'source': 'Kinesis',
@@ -51,7 +51,7 @@ class TestHandler(unittest.TestCase):
         }
         resp = handler(testRec, None)
         mock_fetch.assert_called_once()
-        self.assertTrue(resp)
+        self.assertEqual(resp, [])
 
     def test_local_csv_success(self):
         mOpen = mock_open(read_data='id1,r1.2,pd\nid2,r2.2,pd\n')
@@ -105,13 +105,15 @@ class TestHandler(unittest.TestCase):
     @patch('service.loadCountryCodes', return_value={})
     @patch('service.Process')
     @patch('service.Pipe')
-    def test_file_parser(self, mock_pipe, mock_process, mock_codes):
+    @patch('service.wait')
+    def test_file_parser(self, mock_wait, mock_pipe, mock_process, mock_codes):
         testRows = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
         mock_parent = MagicMock()
         outList = ['success'] * 8 + ['DONE'] * 6
         mock_parent.recv.side_effect = outList
         mock_child = MagicMock()
         mock_pipe.return_value = (mock_parent, mock_child)
+        mock_wait.return_value = [mock_parent]
         res = fileParser(testRows, ['test'])
         self.assertEqual(len(res), 8)
         self.assertEqual(res[7], 'success')


### PR DESCRIPTION
This branch implements a range of changes that support performance improvements in the ETL pipeline. These generally assume greater responsibility for parsing the content of records, taking tasks out of the database manager and updater and moving them here where things can be run more effectively in parallel and not block the I/O of the database while waiting for external services to resolve.

These changes focus on:

- Fetching VIAF records before attempting to insert these records into the database. Doing so removes a major bottleneck on the database layer.
- Updating the output to Kinesis to allow the function to write to multi-sharded streams, giving us the ability to scale the throughput of this step in the application (other factors limit the utility of this to two shards)
- Improving the internal multithreading code to allow for processing larger batches at once, making large scale import jobs much easier