### PR TITLE
Hotfix add corporate query type

### DIFF
--- a/lib/hathiRecord.py
+++ b/lib/hathiRecord.py
@@ -766,7 +766,7 @@ class HathiRecord():
             self.viafRoot, quote_plus(agent.name)
         )
         if (len(list(set(agent.roles) & set(self.corporateRoles))) > 0):
-            reqStr = '{}&queryType=corporate'
+            reqStr = '{}&queryType=corporate'.format(reqStr)
         viafResp = requests.get(reqStr)
         responseJSON = viafResp.json()
         logger.debug(responseJSON)

--- a/lib/hathiRecord.py
+++ b/lib/hathiRecord.py
@@ -392,6 +392,11 @@ class HathiRecord():
 
     viafRoot = 'https://dev-platform.nypl.org/api/v0.1/research-now/viaf-lookup?queryName='  # noqa: E501
 
+    corporateRoles = [
+        'publisher', 'manufacturer', 'repository', 'digitizer',
+        'responsible_organization'
+    ]
+
     def __init__(self, ingestRecord, ingestDateTime=None):
         # Initialize with empty SFR data objects
         # self.ingest contains the source data
@@ -757,9 +762,12 @@ class HathiRecord():
 
     def getVIAF(self, agent):
         logger.info('Querying VIAF for {}'.format(agent.name))
-        viafResp = requests.get('{}{}'.format(
+        reqStr = '{}{}'.format(
             self.viafRoot, quote_plus(agent.name)
-        ))
+        )
+        if (len(list(set(agent.roles) & set(self.corporateRoles))) > 0):
+            reqStr = '{}&queryType=corporate'
+        viafResp = requests.get(reqStr)
         responseJSON = viafResp.json()
         logger.debug(responseJSON)
         if 'viaf' in responseJSON:


### PR DESCRIPTION
This ensures that when looking up corporate names that they are queried with that type for VIAF lookup. Without it the service will either return none or an incorect match. Since this service involves many corporate entities it is especally important to do properly here.