### PR TITLE
HOTFIX Hathi recursive call

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+coverage
+flake8
+python-lambda

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-coverage
-flake8
-python-lambda
 pyyaml
 requests
 requests_oauthlib

--- a/service.py
+++ b/service.py
@@ -77,7 +77,7 @@ def handler(event, context):
             'access_profile',
             'author'
         ]
-    if event['source'] == 'local.file':
+    if event.get('source', None) == 'local.file':
         logger.info('Loading records from local file')
         csvFile = loadLocalCSV(event['localFile'], event['start'], event['size'])
     else:
@@ -122,7 +122,7 @@ def sliceAndRecurse(csvFile, context):
         lambdaClient.invoke(
             FunctionName=context.function_name,
             InvocationType='Event',
-            ClientContext=b64encode(json.dumps({'start': start + 500}).encode('gbk'))
+            ClientContext=b64encode(json.dumps({'start': start + 500}).encode()).decode()
         )
 
     return processingRows

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -42,7 +42,7 @@ class TestHandler(unittest.TestCase):
         resp = handler(testRec, None)
         mock_fetch.assert_called_once()
         mock_parser.assert_called_once()
-        mock_slice.assert_called_once_with(['row1', 'row2'], None)
+        mock_slice.assert_called_once_with(['row1', 'row2'], testRec, None)
         self.assertEqual(resp, [1, 2])
 
     @patch('service.fetchHathiCSV', return_value=['row1', 'row2'])
@@ -60,16 +60,13 @@ class TestHandler(unittest.TestCase):
     @patch('service.boto3')
     def test_sliceAndRecurse_start_0(self, mockBoto):
         mockContext = MagicMock()
-        mockContextClient = MagicMock()
-        mockContextClient.custom = {}
-        mockContext.client_context = mockContextClient
 
         testArray = [i for i in range(750)]
 
         mockClient = MagicMock()
         mockBoto.client.return_value = mockClient
 
-        outRows = sliceAndRecurse(testArray, mockContext)
+        outRows = sliceAndRecurse(testArray, {}, mockContext)
 
         self.assertEqual(len(outRows), 500)
         mockBoto.client.assert_called_once_with('lambda')
@@ -78,16 +75,13 @@ class TestHandler(unittest.TestCase):
     @patch('service.boto3')
     def test_sliceAndRecurse_start_500(self, mockBoto):
         mockContext = MagicMock()
-        mockContextClient = MagicMock()
-        mockContextClient.custom = {'start': 500}
-        mockContext.client_context = mockContextClient
 
         testArray = [i for i in range(750)]
 
         mockClient = MagicMock()
         mockBoto.client.return_value = mockClient
 
-        outRows = sliceAndRecurse(testArray, mockContext)
+        outRows = sliceAndRecurse(testArray, {'start': 500}, mockContext)
 
         self.assertEqual(len(outRows), 250)
         mockBoto.client.assert_not_called()


### PR DESCRIPTION
The new data enhancement steps (mainly the fetching of VIAF numbers at this phase) have caused a large number of timeouts in this function as it cannot complete its execution in the 15 minute window for lambda functions.

This splits the received records into chunks of 500 and then recursively calls itself to process the remaining records. This limits the individual execution itme for each call and increases the parallelization so that the overall execution time should take no longer than 15 minutes